### PR TITLE
fix: category row is now fully tappable

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/categories/CategoriesView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/categories/CategoriesView.swift
@@ -16,15 +16,20 @@ struct CategoriesView: View {
     var body: some View {
         NavigationView {
             List(categories, id: \.self) { categorie in
-                HStack(spacing: 4) {
-                    if categorie == self.selectedCategory {
-                        Image(systemName: "checkmark").foregroundColor(.bell)
-                    }
-                    Image(categorie.iconName()).resizable().frame(width: 25, height: 25)
-                    Text(categorie.rawValue.capitalized).foregroundColor(.text)
-                }.onTapGesture {
+                Button(action: {
                     self.selectedCategory = categorie
                     self.presentationMode.wrappedValue.dismiss()
+                }) {
+                    HStack(spacing: 4) {
+                        if categorie == self.selectedCategory {
+                            Image(systemName: "checkmark").foregroundColor(.bell)
+                        }
+                        Image(categorie.iconName())
+                            .renderingMode(.original)
+                            .resizable()
+                            .frame(width: 25, height: 25)
+                        Text(categorie.rawValue.capitalized).foregroundColor(.text)
+                    }
                 }
                 }.navigationBarTitle(Text("Categories"), displayMode: .inline)
         }.navigationViewStyle(StackNavigationViewStyle())


### PR DESCRIPTION
## Description
Before, the Category rows could only be tapped by tapping on the text in the cell. This convert the category cell to a button so the entire row is tappable. It should look the same.

## Screenshot(s)
![Simulator Screen Shot - iPhone 11 - 2020-04-16 at 18 29 23](https://user-images.githubusercontent.com/674503/79512812-37124e00-8010-11ea-98a0-2334668705cf.png)