### PR TITLE
fix: images display correctly

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemImage.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemImage.swift
@@ -19,6 +19,7 @@ struct ItemImage : View {
                 Image(uiImage: self.imageLoader.image!)
                     .resizable()
                     .renderingMode(.original)
+                    .aspectRatio(contentMode: .fit)
                     .frame(width: size, height: size)
                     .animation(.spring())
                     .onAppear{


### PR DESCRIPTION
## Description
before, items looked squashed. now they don't!

## Screenshots
|                                                                                                                                                            Before |  After                                                                                                                                                            |
|------------------------------------------------------------------------------------------------------------------------------------------------------------------:|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| ![Simulator Screen Shot - iPhone 11 - 2020-04-16 at 19 13 54](https://user-images.githubusercontent.com/674503/79515384-79d72480-8016-11ea-8157-188be2d50912.png) | ![Simulator Screen Shot - iPhone 11 - 2020-04-16 at 19 13 10](https://user-images.githubusercontent.com/674503/79515391-7c397e80-8016-11ea-82ea-88ef8d38066e.png) |


