### PR TITLE
fix: add a split-screen placeholder view

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
@@ -61,6 +61,13 @@ struct ItemsListView: View {
         return ActionSheet(title: Text("Sort items"), buttons: buttons)
     }
     
+    func makeDetailView() -> some View {
+        Text("Please choose an item.")
+            .foregroundColor(.secondary)
+            .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+            .background(Color.dialogue)
+    }
+    
     var body: some View {
         NavigationView {
             List {
@@ -80,6 +87,7 @@ struct ItemsListView: View {
             .sheet(isPresented: $showFilterSheet, content: { CategoriesView(categories: self.categories,
                                                                             selectedCategory: self.$viewModel.categorie) })
             .actionSheet(isPresented: $showSortSheet, content: { self.sortSheet })
+            makeDetailView()
         }.onAppear {
             self.viewModel.categorie = self.categories.first!
         }


### PR DESCRIPTION
## Description
When running in split screen, the colors looked off. This adds a placeholder view.

## Screenshots
<img width="500" alt="Screen Shot 2020-04-16 at 7 34 25 PM" src="https://user-images.githubusercontent.com/674503/79516448-6d080000-8019-11ea-8023-895de335c7d2.png">
