### PR TITLE
fix: add empty state to the collection screen

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/collection/CollectionListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/collection/CollectionListView.swift
@@ -22,6 +22,12 @@ struct CollectionListView: View {
                                                                     .listRowBackground(Color.dialogue)
                     }
                 }
+                .overlay(Group {
+                    if collection.items.isEmpty {
+                        Text("Tap the stars to start collecting!")
+                            .foregroundColor(.secondary)
+                    }
+                })
             }
             .background(Color.dialogue)
             .navigationBarTitle(Text("Collection"),


### PR DESCRIPTION
## Description
This was an empty screen. Now it gives the user some instruction.

## Screenshot
<img width="300" alt="Screen Shot 2020-04-16 at 7 34 25 PM" src="https://user-images.githubusercontent.com/674503/79516801-6fb72500-801a-11ea-819b-fc07e9990fc1.png">
