### PR TITLE
fix: force light content in status bar & dark mode fixes

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/Colors.xcassets/text.colorset/Contents.json
+++ b/ACHNBrowserUI/ACHNBrowserUI/Colors.xcassets/text.colorset/Contents.json
@@ -11,6 +11,24 @@
         }
       },
       "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "display-p3",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.431",
+          "green" : "0.553",
+          "red" : "0.630"
+        }
+      },
+      "idiom" : "universal"
     }
   ],
   "info" : {

--- a/ACHNBrowserUI/ACHNBrowserUI/Info.plist
+++ b/ACHNBrowserUI/ACHNBrowserUI/Info.plist
@@ -48,12 +48,16 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
@@ -21,10 +21,8 @@ struct VillagersListView: View {
                     Text(villager.name["name-en"] ?? "")
                 }
             }
-            .onAppear(perform: viewModel.fetch)
-            .background(Color.dialogue)
-            .navigationBarTitle(Text("Villagers"),
-                                displayMode: .inline)
+        }.onAppear {
+            self.viewModel.fetch()
         }
     }
 }


### PR DESCRIPTION
- Status bar should always be white, looks better.
- Made the text color slightly lighter in dark mode so it is easier to read.