### PR TITLE
fix: proper villager search copy

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/SearchField.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/SearchField.swift
@@ -11,10 +11,11 @@ import SwiftUI
 
 struct SearchField: View {
     @Binding var searchText: String
-    
+    var placeholder: LocalizedStringKey = "Search an item"
+
     var body: some View {
         HStack {
-            TextField("Search an item", text: $searchText)
+            TextField(placeholder, text: $searchText)
             if !searchText.isEmpty {
                 Button(action: {
                     self.searchText = ""

--- a/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
@@ -31,7 +31,8 @@ struct VillagersListView: View {
     var body: some View {
         NavigationView {
             List {
-                SearchField(searchText: $viewModel.searchText)
+                SearchField(searchText: $viewModel.searchText,
+                            placeholder: "Search a villager")
                     .listRowBackground(Color.grass)
                     .foregroundColor(.white)
                 ForEach(currentVillagers) { villager in


### PR DESCRIPTION
placeholder was "Search an item" now it is "Search a villager"