### PR TITLE
fix: lists are working as expected after doing a search on macOS

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModifiers/DismissingKeyboardOnSwipe.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModifiers/DismissingKeyboardOnSwipe.swift
@@ -11,7 +11,11 @@ import SwiftUI
 // See https://stackoverflow.com/questions/56491386/how-to-hide-keyboard-when-using-swiftui
 struct DismissingKeyboardOnSwipe: ViewModifier {
     func body(content: Content) -> some View {
-        content.gesture(swipeGesture)
+        #if os(macOS)
+        return content
+        #else
+        return content.gesture(swipeGesture)
+        #endif
     }
 
     private var swipeGesture: some Gesture {


### PR DESCRIPTION
* Previously crashed after doing a search as the ViewModifier
DismissingKeyboardOnSwipe is useless on macOS and call some iOS only
methods under the hood that leads to crash the app.

* Fix #38