### PR TITLE
Use a StackNavigationViewStyle to fix About view on iPad

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
@@ -106,7 +106,9 @@ struct AboutView: View {
             .environment(\.horizontalSizeClass, .regular)
             .navigationBarTitle(Text("About"), displayMode: .inline)
             .navigationBarItems(leading: dismissButton)
-        }.sheet(item: $selectedSheet, content: makeSheet)
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+        .sheet(item: $selectedSheet, content: makeSheet)
     }
 }
 


### PR DESCRIPTION
Without this set, the About View modal has a sub-split view which leaves a huge gap on the right side of the modal.