### PR TITLE
Add hoverEffects throughout the app

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
+++ b/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		02F2D4462455D81C009741DA /* round-alt-orange@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 02F2D3F62455D81C009741DA /* round-alt-orange@3x.png */; };
 		02F2D4472455D81C009741DA /* simple-orange@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 02F2D3F72455D81C009741DA /* simple-orange@3x.png */; };
 		02F2D4482455D81C009741DA /* simple-mint@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 02F2D3F82455D81C009741DA /* simple-mint@3x.png */; };
+		325C0945246054AF0043B6A7 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 325C0943246053E10043B6A7 /* SwiftUI.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		4C382EE8244E418800F446BA /* DismissingKeyboardOnSwipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C382EE7244E418800F446BA /* DismissingKeyboardOnSwipe.swift */; };
 		4C7FE78324574FB50011E8AB /* ActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7FE78224574FB50011E8AB /* ActivityIndicator.swift */; };
 		4C7FE789245B57A10011E8AB /* AdaptsToSoftwareKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7FE788245B57A10011E8AB /* AdaptsToSoftwareKeyboard.swift */; };
@@ -319,6 +320,7 @@
 		02F2D3F62455D81C009741DA /* round-alt-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-orange@3x.png"; sourceTree = "<group>"; };
 		02F2D3F72455D81C009741DA /* simple-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-orange@3x.png"; sourceTree = "<group>"; };
 		02F2D3F82455D81C009741DA /* simple-mint@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-mint@3x.png"; sourceTree = "<group>"; };
+		325C0943246053E10043B6A7 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
 		4C382EE7244E418800F446BA /* DismissingKeyboardOnSwipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissingKeyboardOnSwipe.swift; sourceTree = "<group>"; };
 		4C7FE78224574FB50011E8AB /* ActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicator.swift; sourceTree = "<group>"; };
 		4C7FE788245B57A10011E8AB /* AdaptsToSoftwareKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptsToSoftwareKeyboard.swift; sourceTree = "<group>"; };
@@ -429,6 +431,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				325C0945246054AF0043B6A7 /* SwiftUI.framework in Frameworks */,
 				69E4BBB0245AE067001035E2 /* UI in Frameworks */,
 				68345589244E4DEF0072FC0C /* ACNHEvents in Frameworks */,
 				69CFCA34245AA62D0059C067 /* Backend in Frameworks */,
@@ -663,6 +666,7 @@
 		6951837324599C26005D28E0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				325C0943246053E10043B6A7 /* SwiftUI.framework */,
 				6951837424599C26005D28E0 /* StoreKit.framework */,
 			);
 			name = Frameworks;

--- a/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
@@ -24,6 +24,46 @@ extension View {
         controller.view.removeFromSuperview()
         return image
     }
+    
+    func safeOnDrag(data: @escaping () -> NSItemProvider) -> AnyView {
+        if #available(iOS 13.4, *) {
+            return AnyView(onDrag(data))
+        } else {
+            return AnyView(self)
+        }
+    }
+    
+    func safeOnHover(action: @escaping (Bool) -> Void) -> AnyView {
+        if #available(iOS 13.4, *) {
+            return AnyView(onHover(perform: action))
+        } else {
+            return AnyView(self)
+        }
+    }
+    
+    func safeHoverEffect(_ type: SafeHoverEffectType = .automatic ) -> AnyView {
+        if #available(iOS 13.4, *) {
+            var hoverEffectType: HoverEffect
+            
+            switch(type) {
+            case .lift:
+                hoverEffectType = .lift
+                
+            case .highlight:
+                hoverEffectType = .highlight
+                
+            case .automatic:
+                fallthrough
+                
+            default:
+                hoverEffectType = .automatic
+            }
+            
+            return AnyView(hoverEffect(hoverEffectType))
+        } else {
+            return AnyView(self)
+        }
+    }
 }
 
 extension UIView {
@@ -37,3 +77,13 @@ extension UIView {
         }
     }
 }
+
+// These enums can be removed and safeHoverEffect converted to just hoverEffect throughout if we no longer need to support < iPadOS 13.4
+enum SafeHoverEffectType {
+    case automatic
+    case lift
+    case highlight
+}
+
+// Constant used throughout the app to add padding around text and icon buttons for improved tapability + match Apple's default hoverEffects
+let hoverPadding: CGFloat = 10

--- a/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
@@ -30,6 +30,9 @@ struct AboutView: View {
         }, label: {
             Text("Dismiss")
         })
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:-hoverPadding)
     }
     
     private func makeSheet(_ sheet: Sheet) -> some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/dashboard/DashboardView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/dashboard/DashboardView.swift
@@ -40,6 +40,9 @@ struct DashboardView: View {
         }, label: {
             Image(systemName: "slider.horizontal.3").imageScale(.medium)
         })
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     private var aboutButton: some View {
@@ -48,6 +51,9 @@ struct DashboardView: View {
         }, label: {
             Image(systemName: "info.circle").imageScale(.large)
         })
+        .padding(10)
+        .safeHoverEffect()
+        .offset(x:-10)
     }
     
     private func makeSheet(_ sheet: Sheet) -> some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
@@ -33,6 +33,9 @@ struct ItemsListView: View {
             Image(systemName: viewModel.sort == nil ? "arrow.up.arrow.down.circle" : "arrow.up.arrow.down.circle.fill")
                 .imageScale(.large)
         }
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     private var layoutButton: some View {
@@ -42,6 +45,9 @@ struct ItemsListView: View {
             Image(systemName: itemRowsDisplayMode == .big ? "rectangle.grid.1x2" : "list.dash")
                 .imageScale(.large)
         }
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     private var sortSheet: ActionSheet {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
@@ -136,6 +136,9 @@ extension ItemDetailView {
         }) {
             Image(systemName: "square.and.arrow.up").imageScale(.large)
         }
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     private var navButtons: some View {
@@ -150,7 +153,7 @@ extension ItemDetailView {
         Section(header: SectionHeaderView(text: "Variants")) {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack {
-                    ForEach(itemViewModel.item.variants!) { variant in
+                ForEach(itemViewModel.item.variants!) { variant in
                         ItemImage(path: variant.filename,
                                   size: 75)
                             .onTapGesture {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -26,6 +26,9 @@ struct SettingsView: View {
         }, label: {
             Text("Dismiss")
         })
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:-hoverPadding)
     }
     
     var saveButton: some View {
@@ -40,6 +43,9 @@ struct SettingsView: View {
         }, label: {
             Text("Save")
         })
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     var body: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/LikeButtonView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/LikeButtonView.swift
@@ -66,6 +66,9 @@ struct LikeButtonView: View {
         .scaleEffect(self.isInCollection ? 1.2 : 1.0)
         .buttonStyle(BorderlessButtonStyle())
         .animation(.interactiveSpring())
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
 }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/subscription/SubscribeView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/subscription/SubscribeView.swift
@@ -34,6 +34,9 @@ struct SubscribeView: View {
         }) {
             Text("Close")
         }
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
     
     private var upperPart: some View {
@@ -88,7 +91,7 @@ struct SubscribeView: View {
                 .fontWeight(.bold)
                 .foregroundColor(.white)
                 .frame(width: 290, height: 30)
-        }.buttonStyle(PlainRoundedButton()).accentColor(.grass)
+        }.buttonStyle(PlainRoundedButton()).accentColor(.grass).safeHoverEffect()
     }
     
     private var lowerPart: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
@@ -27,6 +27,9 @@ struct TurnipsFormView: View {
         Button(action: save) {
             Text("Save")
         }
+        .padding(hoverPadding)
+        .safeHoverEffect()
+        .offset(x:hoverPadding)
     }
 
     private func save() {


### PR DESCRIPTION
There are a few tricks in here:

For nav bar items, we need to add in a padding and offset (+ or - depending on which side it appears), stored as a constant in the View extensions file, to simulate the same padding that Apple gives UIKit for free with nav bar button items.

3 new View extensions have been added, though only one is used right now, all prefixed with the word `safe`, eg, `safeHoverEffect`, which takes the same parameters as the normal 13.4+ `safeHover`, `.automatic` (default), `.lift`, or `.highlight` so that the code will run just fine on any >= 13.0 && < 13.4 devices. To not throw a "Symbol Not Found" error, `SwiftUI.framework` needs to be optionally linked into the build phases (thanks to @mike_p3 who makes the Strong app for that tweak!)

Might be worth refactoring the various padding and offsets around the `safeHoverEffect()` in the future if we use the same button in multiple places for example.