### PR TITLE
Refactor hoverEffect for Bar Items for more concise code + clarity

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
@@ -64,6 +64,19 @@ extension View {
             return AnyView(self)
         }
     }
+    
+    func safeHoverEffectBarItem(position: BarItemPosition) -> AnyView {
+        let hoverPadding: CGFloat = 10
+        
+        // For leading bar items, we need to apply a negative offset equal to the overall padding to imitate Apple's styling in UIKit
+        let offset = position == .leading ? -hoverPadding : hoverPadding
+        
+        return AnyView(self
+            .padding(hoverPadding)
+            .safeHoverEffect()
+            .offset(x:offset)
+        )
+    }
 }
 
 extension UIView {
@@ -85,5 +98,8 @@ enum SafeHoverEffectType {
     case highlight
 }
 
-// Constant used throughout the app to add padding around text and icon buttons for improved tapability + match Apple's default hoverEffects
-let hoverPadding: CGFloat = 10
+// To simulate Apple's default UIKit hoverEffect padding on bar items, we need to specify if it's on the left or right and apply the right offset
+enum BarItemPosition {
+    case leading
+    case trailing
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/about/AboutView.swift
@@ -30,9 +30,7 @@ struct AboutView: View {
         }, label: {
             Text("Dismiss")
         })
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:-hoverPadding)
+        .safeHoverEffectBarItem(position: .leading)
     }
     
     private func makeSheet(_ sheet: Sheet) -> some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/dashboard/DashboardView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/dashboard/DashboardView.swift
@@ -40,9 +40,7 @@ struct DashboardView: View {
         }, label: {
             Image(systemName: "slider.horizontal.3").imageScale(.medium)
         })
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     private var aboutButton: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
@@ -33,9 +33,7 @@ struct ItemsListView: View {
             Image(systemName: viewModel.sort == nil ? "arrow.up.arrow.down.circle" : "arrow.up.arrow.down.circle.fill")
                 .imageScale(.large)
         }
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     private var layoutButton: some View {
@@ -45,9 +43,7 @@ struct ItemsListView: View {
             Image(systemName: itemRowsDisplayMode == .big ? "rectangle.grid.1x2" : "list.dash")
                 .imageScale(.large)
         }
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     private var sortSheet: ActionSheet {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
@@ -136,9 +136,7 @@ extension ItemDetailView {
         }) {
             Image(systemName: "square.and.arrow.up").imageScale(.large)
         }
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     private var navButtons: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -26,9 +26,7 @@ struct SettingsView: View {
         }, label: {
             Text("Dismiss")
         })
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:-hoverPadding)
+        .safeHoverEffectBarItem(position: .leading)
     }
     
     var saveButton: some View {
@@ -43,9 +41,7 @@ struct SettingsView: View {
         }, label: {
             Text("Save")
         })
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     var body: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -48,26 +48,7 @@ struct SettingsView: View {
         })
         .safeHoverEffectBarItem(position: .leading)
     }
-<<<<<<< HEAD
-    
-    var saveButton: some View {
-        Button(action: {
-            AppUserDefaults.islandName = self.islandName
-            AppUserDefaults.hemisphere = self.selectedHemisphere
-            AppUserDefaults.fruit = self.selectedFruit
-            AppUserDefaults.nookShop = self.selectedNookShop
-            AppUserDefaults.ableSisters = self.selectedAbleSisters
-            AppUserDefaults.residentService = self.selectedResidentService
-            self.presentationMode.wrappedValue.dismiss()
-        }, label: {
-            Text("Save")
-        })
-        .safeHoverEffectBarItem(position: .trailing)
-    }
-    
-=======
-        
->>>>>>> Dimillian/master
+
     var body: some View {
         NavigationView {
             Form {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/LikeButtonView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/LikeButtonView.swift
@@ -66,9 +66,7 @@ struct LikeButtonView: View {
         .scaleEffect(self.isInCollection ? 1.2 : 1.0)
         .buttonStyle(BorderlessButtonStyle())
         .animation(.interactiveSpring())
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
 }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/subscription/SubscribeView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/subscription/SubscribeView.swift
@@ -34,9 +34,7 @@ struct SubscribeView: View {
         }) {
             Text("Close")
         }
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
     
     private var upperPart: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
@@ -27,9 +27,7 @@ struct TurnipsFormView: View {
         Button(action: save) {
             Text("Save")
         }
-        .padding(hoverPadding)
-        .safeHoverEffect()
-        .offset(x:hoverPadding)
+        .safeHoverEffectBarItem(position: .trailing)
     }
 
     private func save() {


### PR DESCRIPTION
Also has the benefit of consolidating the hoverPadding constant in the
one place where it’s needed. Pass in a position whenever you use this, `.leading` or `.trailing` to match `navigationBarItems`.