### PR TITLE
feat: show selected alternate app icon

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -96,8 +96,10 @@ struct SettingsView: View {
                 }
                 
                 Section(header: SectionHeaderView(text: "App Settings")) {
-                    NavigationLink(destination: AppIconPickerView()) {
-                        Text("App Icon")
+                    if UIApplication.shared.supportsAlternateIcons {
+                        NavigationLink(destination: AppIconPickerView()) {
+                            Text("App Icon")
+                        }
                     }
                     Button(action: {
                         self.subscriptionManager.restorePurchase()


### PR DESCRIPTION
now you can see the selected icon in the app.

![Simulator Screen Shot - iPhone 11 Pro - 2020-05-04 at 19 53 32](https://user-images.githubusercontent.com/674503/81024272-f2c0e380-8e40-11ea-8e1c-552fdeb78392.png)
