### PR TITLE
feat: integrate Catalyst titlebar into app window

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/SceneDelegate.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/SceneDelegate.swift
@@ -53,6 +53,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             let window = UIWindow(windowScene: windowScene)
             window.rootViewController = UIHostingController(rootView: contentView)
             self.window = window
+			#if targetEnvironment(macCatalyst)
+			window.windowScene?.titlebar?.titleVisibility = .hidden
+			#endif
             window.makeKeyAndVisible()
         }
     }


### PR DESCRIPTION
Setting the `titleVisibility` of the window makes it so the titlebar that appears by default in Catalyst apps is integrated into the main app window, with the close/minimize/zoom buttons appearing as part of the window itself. 
<img width="789" alt="Screen Shot 2020-05-04 at 9 21 56 PM" src="https://user-images.githubusercontent.com/49624366/81030135-4a654c00-8e4d-11ea-801d-306136d4ba20.png">
