### PR TITLE
Use first supported preferred language

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/LocalizedItemsService.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/LocalizedItemsService.swift
@@ -31,7 +31,7 @@ public struct LocalizedItemService {
     private var localizationDYI: [Int: LocalizedItem] = [:]
     
     init() {
-        if let preferredIdentifier = Locale.preferredLanguages.first {
+        if let preferredIdentifier = Locale.preferredLanguages.first(where: LocalizedItemService.supportsLanguage) {
             self.currentLocale = Locale(identifier: preferredIdentifier)
         } else {
             self.currentLocale = Locale.current
@@ -60,5 +60,9 @@ public struct LocalizedItemService {
             Dictionary(uniqueKeysWithValues: items.filter { $0.DiyRecipe != nil }
                 .map { ($0.DiyRecipe!.decimal, $0) })
             )
+    }
+    
+    private static func supportsLanguage(_ landuageCode: String) -> Bool {
+        return Bundle.main.url(forResource: Self.filePrefix + landuageCode, withExtension: "json") != nil
     }
 }


### PR DESCRIPTION
Thanks for your great implementation of #44!

The only edge case I've found is the following:
Let's assume your preferred languages are Dansk, German, English.
Currently iOS will pick German for the UI, but `LocalizedItemService` would pick the unsupported Dansk and would therefore fall back to English.

With this PR both contents and the UI will be displayed in German.