### PR TITLE
[Update] Feat/turnips chart set sticky vertical legend

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/extensions/View.swift
@@ -79,6 +79,21 @@ extension View {
     }
 }
 
+extension View {
+    func propagateHeight<K: PreferenceKey>(_ key: K.Type) -> some View where K.Value == CGFloat? {
+        overlay(
+            GeometryReader { proxy in
+                Color.clear
+                    .anchorPreference(key: key, value: .bounds, transform: { proxy[$0].height })
+            }
+        )
+    }
+    
+    func onHeightPreferenceChange<K: PreferenceKey>(_ key: K.Type = K.self, storeValueIn storage: Binding<CGFloat?>) -> some View where K.Value == CGFloat? {
+        onPreferenceChange(key, perform: { storage.wrappedValue = $0 })
+    }
+}
+
 extension UIView {
     public func asImage() -> UIImage {
         UIGraphicsBeginImageContextWithOptions(bounds.size, true, UIScreen.main.scale)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartBottomLegendView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartBottomLegendView.swift
@@ -10,18 +10,32 @@ import SwiftUI
 import Backend
 
 struct TurnipsChartBottomLegendView: View {
+    private struct TextsHeightPreferenceKey: PreferenceKey {
+        static var defaultValue: CGFloat?
+        static func reduce(value: inout CGFloat?, nextValue: () -> CGFloat?) {
+            if let newValue = nextValue() { value = newValue }
+        }
+    }
+    
     let predictions: TurnipPredictions
     private let weekdays = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+    
+    @State private var textsHeight: CGFloat?
 
     var body: some View {
         GeometryReader(content: computeTexts)
+            .onHeightPreferenceChange(TextsHeightPreferenceKey.self, storeValueIn: $textsHeight)
+            .frame(height: self.textsHeight)
+            .fixedSize(horizontal: false, vertical: true)
     }
 
     func computeTexts(for geometry: GeometryProxy) -> some View {
+        
         let rect = geometry.frame(in: .local)
         let (_, _, _, ratioX) = predictions.minMax?.roundedMinMaxAndRatios(rect: rect) ?? (0, 0, 0, 0)
         let count = predictions.minMax?.count ?? 0
         return texts(count: count, ratioX: ratioX)
+            .propagateHeight(TextsHeightPreferenceKey.self)
     }
 
     func texts(count: Int, ratioX: CGFloat) -> some View {
@@ -37,6 +51,7 @@ struct TurnipsChartBottomLegendView: View {
                 }
             }
         }
+        
     }
 
     func meridiem(offset: Int, ratioX: CGFloat) -> some View {
@@ -62,4 +77,23 @@ struct TurnipsChartBottomLegendView: View {
 
 private extension Int {
     var isAM: Bool { self == 0 || isMultiple(of: 2) }
+}
+
+struct TurnipsChartBottomLegendView_Previews: PreviewProvider {
+    static var previews: some View {
+        TurnipsChartBottomLegendView(predictions: predictions)
+    }
+    
+    static let predictions = TurnipPredictions(
+        minBuyPrice: 83,
+        averagePrices: averagePrices,
+        minMax: minMax,
+        averageProfits: averageProfits
+    )
+    
+    static let averagePrices = [89, 85, 88, 104, 110, 111, 111, 111, 106, 98, 82, 77]
+    
+    static let minMax = [[38, 142], [33, 142], [29, 202], [24, 602], [19, 602], [14, 602], [9, 602], [29, 602], [24, 602], [19, 602], [14, 202], [9, 201]]
+    
+    static let averageProfits = [89, 85, 88, 104, 110, 111, 111, 111, 106, 98, 82, 77]
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartBottomLegendView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartBottomLegendView.swift
@@ -81,19 +81,6 @@ private extension Int {
 
 struct TurnipsChartBottomLegendView_Previews: PreviewProvider {
     static var previews: some View {
-        TurnipsChartBottomLegendView(predictions: predictions)
+        TurnipsChartBottomLegendView(predictions: TurnipsChartView_Previews.predictions)
     }
-    
-    static let predictions = TurnipPredictions(
-        minBuyPrice: 83,
-        averagePrices: averagePrices,
-        minMax: minMax,
-        averageProfits: averageProfits
-    )
-    
-    static let averagePrices = [89, 85, 88, 104, 110, 111, 111, 111, 106, 98, 82, 77]
-    
-    static let minMax = [[38, 142], [33, 142], [29, 202], [24, 602], [19, 602], [14, 602], [9, 602], [29, 602], [24, 602], [19, 602], [14, 202], [9, 201]]
-    
-    static let averageProfits = [89, 85, 88, 104, 110, 111, 111, 111, 106, 98, 82, 77]
 }


### PR DESCRIPTION
- Everything is now done using preferences and anchors.
- Convenient height propagation methods has been added to a view extension to be re-used.