### PR TITLE
Localization: Added missing fish source to localization

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/de.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/de.lproj/Localizable.strings
@@ -630,5 +630,8 @@ Du kannst das Abonnement jederzeit in deinen iTunes Kontoeinstellungen beenden. 
 "Wrapping a present" = "Geschenk verpacken";
 "X-Small shadow when fishing" = "Sehr kleiner Schatten beim Angeln";
 "Zipper" = "Ohs T. Hase";
+// Added 2020-05-12
+"Sea" = "Meer";
+"Sea (raining)" = "Meer (bei Regen)";
 
 // to be continued


### PR DESCRIPTION
How could I missed them? They even had been inside my first commit of #107 