### PR TITLE
Sort items using localized comparision

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
@@ -30,8 +30,8 @@ class ItemsViewModel: ObservableObject {
             guard let sort = sort else { return }
             switch sort {
             case .name:
-                let compare: (String, String) -> Bool = sort == oldValue ? (<) : (>)
-                sortedItems = items.sorted{ compare($0.localizedName, $1.localizedName) }
+                let order: ComparisonResult = sort == oldValue ? .orderedAscending : .orderedDescending
+                sortedItems = items.sorted{ $0.localizedName.localizedCompare($1.localizedName) == order }
             case .buy:
                 let compare: (Int, Int) -> Bool = sort == oldValue ? (<) : (>)
                 sortedItems = items.filter{ $0.buy != nil}.sorted{ compare($0.buy!, $1.buy!) }
@@ -62,7 +62,7 @@ class ItemsViewModel: ObservableObject {
 
         itemCancellable = Items.shared.$categories
             .sink { [weak self] in
-            self?.items = $0[category]?.sorted{ $0.localizedName < $1.localizedName } ?? []
+                self?.items = $0[category]?.sorted{ $0.localizedName.localizedCompare($1.localizedName) == .orderedAscending } ?? []
         }
     }
 


### PR DESCRIPTION
Relies on localized comparison for sorting items to correctly handle accents and umlauts.

E.g. in German this will treat `Ä` and `Á` as `A` instead of ordering them after `Z`.


| Before | After |
| --- | --- |
| Umlauts/Accents at the end | Umlauts/accents within their normal variants |
| <img alt="Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-12 at 20 54 49" src="https://user-images.githubusercontent.com/2100336/81733843-eec14100-9492-11ea-91e7-9fc057557cd2.png" width="200"> | <img alt="Simulator Screen Shot - iPhone 11 Pro Max - 2020-05-12 at 20 56 40" src="https://user-images.githubusercontent.com/2100336/81733982-216b3980-9493-11ea-87ca-486483cfdbfc.png" width="200"> |

