### PR TITLE
feat(Turnips): use average color for entered displayed values in Chart

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartValuesView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartValuesView.swift
@@ -21,17 +21,17 @@ struct TurnipsChartValuesView: View {
                 .foregroundColor(.graphMinMax)
                 .modifier(ValueModifier(backgroundColor: Color.acBackground))
                 .position(data[position].min.position)
+            Text("\(data[position].max.value)")
+                .bold()
+                .foregroundColor(.graphMinMax)
+                .modifier(ValueModifier(backgroundColor: Color.acBackground))
+                .position(data[position].max.position)
             Text("\(data[position].average.value)")
                 .bold()
                 .foregroundColor(.graphAverage)
                 .saturation(5)
                 .modifier(ValueModifier(backgroundColor: Color.acHeaderBackground))
                 .position(data[position].average.position)
-            Text("\(data[position].max.value)")
-                .bold()
-                .foregroundColor(.graphMinMax)
-                .modifier(ValueModifier(backgroundColor: Color.acBackground))
-                .position(data[position].max.position)
         }
     }
 }


### PR DESCRIPTION
* Previously, it was the minMax color value because it was on the bottom
of the ZStack. As average capsule color is more readable IMO, we choose
this one