### PR TITLE
Dashboard: organize widgets

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
+++ b/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4CEEFBD92477D9E900663590 /* TurnipsMinMaxPriceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEEFBD82477D9E900663590 /* TurnipsMinMaxPriceRow.swift */; };
 		4CEEFBDB2477E58500663590 /* TurnipsPriceRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CEEFBDA2477E58500663590 /* TurnipsPriceRow.swift */; };
+		157C03E7247AE56600568917 /* TodaySectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157C03E6247AE56600568917 /* TodaySectionView.swift */; };
 		690A72C924752BF4001E7294 /* villagersLikes in Resources */ = {isa = PBXBuildFile; fileRef = 690A72C824752BF4001E7294 /* villagersLikes */; };
 		69157B7E2471A5A1005B9002 /* TodayMysteryIslandsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69157B6D247121ED005B9002 /* TodayMysteryIslandsSection.swift */; };
 		69157B7F2471A5A1005B9002 /* TodayNookazonSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 693E2BC3246689C500B85CB8 /* TodayNookazonSection.swift */; };
@@ -195,6 +196,87 @@
 		024363D62465EA15006A37A0 /* TodayTasksSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayTasksSection.swift; sourceTree = "<group>"; };
 		024363D72465EA15006A37A0 /* TodayCollectionProgressSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TodayCollectionProgressSection.swift; sourceTree = "<group>"; };
 		028620742454C32800795719 /* AppIconPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconPickerView.swift; sourceTree = "<group>"; };
+		02F2D3A82455D81C009741DA /* bookmark-gold@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-gold@2x.png"; sourceTree = "<group>"; };
+		02F2D3A92455D81C009741DA /* simple-blueberry@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-blueberry@2x.png"; sourceTree = "<group>"; };
+		02F2D3AA2455D81C009741DA /* round-blueberry@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-blueberry@2x.png"; sourceTree = "<group>"; };
+		02F2D3AB2455D81C009741DA /* round-orange@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-orange@2x.png"; sourceTree = "<group>"; };
+		02F2D3AC2455D81C009741DA /* bookmark-mint@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-mint@2x.png"; sourceTree = "<group>"; };
+		02F2D3AD2455D81C009741DA /* round-alt-cocoa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-cocoa@2x.png"; sourceTree = "<group>"; };
+		02F2D3AE2455D81C009741DA /* bookmark-blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-blue@2x.png"; sourceTree = "<group>"; };
+		02F2D3AF2455D81C009741DA /* bookmark-cactus@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-cactus@2x.png"; sourceTree = "<group>"; };
+		02F2D3B02455D81C009741DA /* round-alt-cactus@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-cactus@2x.png"; sourceTree = "<group>"; };
+		02F2D3B12455D81C009741DA /* simple-cactus@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-cactus@2x.png"; sourceTree = "<group>"; };
+		02F2D3B22455D81C009741DA /* simple-lime@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-lime@2x.png"; sourceTree = "<group>"; };
+		02F2D3B32455D81C009741DA /* bookmark-pink@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-pink@2x.png"; sourceTree = "<group>"; };
+		02F2D3B42455D81C009741DA /* round-alt-sky@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-sky@2x.png"; sourceTree = "<group>"; };
+		02F2D3B52455D81C009741DA /* round-blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-blue@2x.png"; sourceTree = "<group>"; };
+		02F2D3B62455D81C009741DA /* bookmark-cocoa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-cocoa@2x.png"; sourceTree = "<group>"; };
+		02F2D3B72455D81C009741DA /* round-pink@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-pink@2x.png"; sourceTree = "<group>"; };
+		02F2D3B82455D81C009741DA /* round-alt-lime@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-lime@2x.png"; sourceTree = "<group>"; };
+		02F2D3B92455D81C009741DA /* round-gold@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-gold@2x.png"; sourceTree = "<group>"; };
+		02F2D3BA2455D81C009741DA /* round-sky@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-sky@2x.png"; sourceTree = "<group>"; };
+		02F2D3BB2455D81C009741DA /* bookmark-sky@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-sky@2x.png"; sourceTree = "<group>"; };
+		02F2D3BC2455D81C009741DA /* round-mint@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-mint@2x.png"; sourceTree = "<group>"; };
+		02F2D3BD2455D81C009741DA /* simple-cocoa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-cocoa@2x.png"; sourceTree = "<group>"; };
+		02F2D3BE2455D81C009741DA /* round-alt-pink@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-pink@2x.png"; sourceTree = "<group>"; };
+		02F2D3BF2455D81C009741DA /* round-lime@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-lime@2x.png"; sourceTree = "<group>"; };
+		02F2D3C02455D81C009741DA /* round-alt-blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-blue@2x.png"; sourceTree = "<group>"; };
+		02F2D3C12455D81C009741DA /* round-alt-mint@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-mint@2x.png"; sourceTree = "<group>"; };
+		02F2D3C22455D81C009741DA /* bookmark-blueberry@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-blueberry@2x.png"; sourceTree = "<group>"; };
+		02F2D3C32455D81C009741DA /* round-alt-blueberry@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-blueberry@2x.png"; sourceTree = "<group>"; };
+		02F2D3C42455D81C009741DA /* round-alt-gold@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-gold@2x.png"; sourceTree = "<group>"; };
+		02F2D3C52455D81C009741DA /* simple-mint@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-mint@2x.png"; sourceTree = "<group>"; };
+		02F2D3C62455D81C009741DA /* simple-orange@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-orange@2x.png"; sourceTree = "<group>"; };
+		02F2D3C72455D81C009741DA /* round-alt-orange@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-orange@2x.png"; sourceTree = "<group>"; };
+		02F2D3C82455D81C009741DA /* bookmark-orange@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-orange@2x.png"; sourceTree = "<group>"; };
+		02F2D3C92455D81C009741DA /* simple-gold@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-gold@2x.png"; sourceTree = "<group>"; };
+		02F2D3CA2455D81C009741DA /* round-cactus@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-cactus@2x.png"; sourceTree = "<group>"; };
+		02F2D3CB2455D81C009741DA /* simple-sky@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-sky@2x.png"; sourceTree = "<group>"; };
+		02F2D3CC2455D81C009741DA /* bookmark-lime@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-lime@2x.png"; sourceTree = "<group>"; };
+		02F2D3CD2455D81C009741DA /* simple-pink@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-pink@2x.png"; sourceTree = "<group>"; };
+		02F2D3CE2455D81C009741DA /* round-cocoa@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-cocoa@2x.png"; sourceTree = "<group>"; };
+		02F2D3CF2455D81C009741DA /* simple-blue@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-blue@2x.png"; sourceTree = "<group>"; };
+		02F2D3D12455D81C009741DA /* round-alt-sky@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-sky@3x.png"; sourceTree = "<group>"; };
+		02F2D3D22455D81C009741DA /* bookmark-pink@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-pink@3x.png"; sourceTree = "<group>"; };
+		02F2D3D32455D81C009741DA /* simple-lime@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-lime@3x.png"; sourceTree = "<group>"; };
+		02F2D3D42455D81C009741DA /* simple-cactus@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-cactus@3x.png"; sourceTree = "<group>"; };
+		02F2D3D52455D81C009741DA /* round-alt-cactus@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-cactus@3x.png"; sourceTree = "<group>"; };
+		02F2D3D62455D81C009741DA /* bookmark-cactus@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-cactus@3x.png"; sourceTree = "<group>"; };
+		02F2D3D72455D81C009741DA /* bookmark-blue@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-blue@3x.png"; sourceTree = "<group>"; };
+		02F2D3D82455D81C009741DA /* round-alt-cocoa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-cocoa@3x.png"; sourceTree = "<group>"; };
+		02F2D3D92455D81C009741DA /* round-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-orange@3x.png"; sourceTree = "<group>"; };
+		02F2D3DA2455D81C009741DA /* bookmark-mint@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-mint@3x.png"; sourceTree = "<group>"; };
+		02F2D3DB2455D81C009741DA /* round-blueberry@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-blueberry@3x.png"; sourceTree = "<group>"; };
+		02F2D3DC2455D81C009741DA /* simple-blueberry@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-blueberry@3x.png"; sourceTree = "<group>"; };
+		02F2D3DD2455D81C009741DA /* bookmark-gold@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-gold@3x.png"; sourceTree = "<group>"; };
+		02F2D3DE2455D81C009741DA /* round-mint@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-mint@3x.png"; sourceTree = "<group>"; };
+		02F2D3DF2455D81C009741DA /* bookmark-sky@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-sky@3x.png"; sourceTree = "<group>"; };
+		02F2D3E02455D81C009741DA /* round-sky@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-sky@3x.png"; sourceTree = "<group>"; };
+		02F2D3E12455D81C009741DA /* round-gold@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-gold@3x.png"; sourceTree = "<group>"; };
+		02F2D3E22455D81C009741DA /* round-alt-lime@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-lime@3x.png"; sourceTree = "<group>"; };
+		02F2D3E32455D81C009741DA /* round-pink@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-pink@3x.png"; sourceTree = "<group>"; };
+		02F2D3E42455D81C009741DA /* bookmark-cocoa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-cocoa@3x.png"; sourceTree = "<group>"; };
+		02F2D3E52455D81C009741DA /* round-blue@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-blue@3x.png"; sourceTree = "<group>"; };
+		02F2D3E62455D81C009741DA /* round-alt-gold@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-gold@3x.png"; sourceTree = "<group>"; };
+		02F2D3E72455D81C009741DA /* bookmark-blueberry@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-blueberry@3x.png"; sourceTree = "<group>"; };
+		02F2D3E82455D81C009741DA /* round-alt-blueberry@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-blueberry@3x.png"; sourceTree = "<group>"; };
+		02F2D3E92455D81C009741DA /* round-alt-mint@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-mint@3x.png"; sourceTree = "<group>"; };
+		02F2D3EA2455D81C009741DA /* round-alt-blue@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-blue@3x.png"; sourceTree = "<group>"; };
+		02F2D3EB2455D81C009741DA /* round-lime@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-lime@3x.png"; sourceTree = "<group>"; };
+		02F2D3EC2455D81C009741DA /* round-alt-pink@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-pink@3x.png"; sourceTree = "<group>"; };
+		02F2D3ED2455D81C009741DA /* simple-cocoa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-cocoa@3x.png"; sourceTree = "<group>"; };
+		02F2D3EE2455D81C009741DA /* simple-blue@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-blue@3x.png"; sourceTree = "<group>"; };
+		02F2D3EF2455D81C009741DA /* round-cocoa@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-cocoa@3x.png"; sourceTree = "<group>"; };
+		02F2D3F02455D81C009741DA /* simple-pink@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-pink@3x.png"; sourceTree = "<group>"; };
+		02F2D3F12455D81C009741DA /* bookmark-lime@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-lime@3x.png"; sourceTree = "<group>"; };
+		02F2D3F22455D81C009741DA /* simple-sky@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-sky@3x.png"; sourceTree = "<group>"; };
+		02F2D3F32455D81C009741DA /* round-cactus@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-cactus@3x.png"; sourceTree = "<group>"; };
+		02F2D3F42455D81C009741DA /* bookmark-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "bookmark-orange@3x.png"; sourceTree = "<group>"; };
+		02F2D3F52455D81C009741DA /* simple-gold@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-gold@3x.png"; sourceTree = "<group>"; };
+		02F2D3F62455D81C009741DA /* round-alt-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "round-alt-orange@3x.png"; sourceTree = "<group>"; };
+		02F2D3F72455D81C009741DA /* simple-orange@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-orange@3x.png"; sourceTree = "<group>"; };
+		02F2D3F82455D81C009741DA /* simple-mint@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "simple-mint@3x.png"; sourceTree = "<group>"; };
+		157C03E6247AE56600568917 /* TodaySectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TodaySectionView.swift; path = ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift; sourceTree = SOURCE_ROOT; };
 		22EB1DC0246D4D1F00C62F76 /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3246F93724725C37001A1E06 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		325C0943246053E10043B6A7 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/Frameworks/SwiftUI.framework; sourceTree = DEVELOPER_DIR; };
@@ -386,6 +468,8 @@
 				69157B6D247121ED005B9002 /* TodayMysteryIslandsSection.swift */,
 				693352832473C4B5007EF9AB /* TodaySpecialCharactersSection.swift */,
 				696B4549247A633D00E16252 /* TodayMusicPlayerSection.swift */,
+				693352832473C4B5007EF9AB /* TodaySpecialCharacters.swift */,
+				157C03E6247AE56600568917 /* TodaySectionView.swift */,
 			);
 			path = todayDashboard;
 			sourceTree = "<group>";
@@ -1006,6 +1090,7 @@
 				69157B7F2471A5A1005B9002 /* TodayNookazonSection.swift in Sources */,
 				69157B802471A5A1005B9002 /* UserListFormView.swift in Sources */,
 				69157B812471A5A1005B9002 /* RowLoadingView.swift in Sources */,
+				157C03E7247AE56600568917 /* TodaySectionView.swift in Sources */,
 				69157B822471A5A1005B9002 /* ItemDetailViewModel.swift in Sources */,
 				69157B832471A5A1005B9002 /* TurnipsChartMinBuyPriceCurve.swift in Sources */,
 				4CEEFBD92477D9E900663590 /* TurnipsMinMaxPriceRow.swift in Sources */,

--- a/ACHNBrowserUI/ACHNBrowserUI/SceneDelegate.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/SceneDelegate.swift
@@ -25,6 +25,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             .environmentObject(SubscriptionManager.shared)
             .environmentObject(TurnipPredictionsService.shared)
             .environmentObject(MusicPlayerManager.shared)
+            .environmentObject(AppUserDefaults.shared)
         
         if let windowScene = scene as? UIWindowScene {
             

--- a/ACHNBrowserUI/ACHNBrowserUI/fr.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/fr.lproj/Localizable.strings
@@ -37,12 +37,11 @@ Localizable.strings
 // TodaySectionEditView
 "Drag & Drop to Rearrange" = "Glisser-déposer pour réorganiser";
 "Hidden" = "Caché";
-"Today Sections" = "Sections d'aujourd'hui";
+"Today Sections" = "Sections du dashboard";
 "Done" = "Terminé";
 " to re-order sections." = " pour réorganiser les sections.";
 "Check or un-check" = "Cochez ou décochez";
-" rows to hide sections from the dashboard." = " rows to hide sections from the dashboard.";
-"Your top-most section will be the default detail view on iPad and Mac." = "Your top-most section will be the default detail view on iPad and Mac.";
+" rows to hide sections from the dashboard." = " pour cacher les sections du dashboard";
 // TodayBirthdaySection
 "Birthdays" = "Anniversaires";
 "Today's Birthdays" = "Anniversaires aujourd'hui";

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
@@ -1,0 +1,48 @@
+//
+//  File.swift
+//  
+//
+//  Created by theunimpossible on 5/21/20.
+//
+
+import Foundation
+
+public struct TodaySection: Codable, Hashable, Equatable {
+    public static let nameEvents = "events"
+    public static let nameSpecialCharacters = "specialCharacters"
+    public static let nameCurrentlyAvailable = "currentlyAvailable"
+    public static let nameCollectionProgress = "collectionProgress"
+    public static let nameBirthdays = "birthdays"
+    public static let nameTurnips = "turnips"
+    public static let nameSubscribe = "subscribe"
+    public static let nameMysteryIsland = "mysteryIsland"
+    public static let nameMusic = "music"
+    public static let nameTasks = "tasks"
+    public static let nameNookazon = "nookazon"
+    
+    public static let defaultSectionList: [TodaySection] = [
+        TodaySection(name: Self.nameEvents, enabled: true),
+        TodaySection(name: Self.nameSpecialCharacters, enabled: true),
+        TodaySection(name: Self.nameCurrentlyAvailable, enabled: true),
+        TodaySection(name: Self.nameCollectionProgress, enabled: true),
+        TodaySection(name: Self.nameBirthdays, enabled: true),
+        TodaySection(name: Self.nameTurnips, enabled: true),
+        TodaySection(name: Self.nameTasks, enabled: true),
+        TodaySection(name: Self.nameSubscribe, enabled: true),
+        TodaySection(name: Self.nameMusic, enabled: true),
+        //TodaySection(name: Self.nameNookazon, enabled: true)
+        TodaySection(name: Self.nameMysteryIsland, enabled: true),
+    ]
+    
+    public static func == (lhs: TodaySection, rhs: TodaySection) -> Bool {
+        return lhs.name == rhs.name
+    }
+    
+    public init(name: String, enabled: Bool) {
+        self.name = name
+        self.enabled = enabled
+    }
+
+    public let name: String
+    public var enabled: Bool
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/ACNHApiService.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/services/ACNHApiService.swift
@@ -10,7 +10,7 @@ import Foundation
 import Combine
 
 public struct ACNHApiService {
-    public static let BASE_URL = URL(string: "http://acnhapi.com/")!
+    public static let BASE_URL = URL(string: "http://acnhapi.com/v1/")!
     private static var cache: [String: Codable] = [:]
     
     public enum Endpoint {

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/utils/AppUserDefault.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/utils/AppUserDefault.swift
@@ -75,6 +75,13 @@ public class AppUserDefaults: ObservableObject {
         }
     }
     
+    @UserDefaultCodable("today_sections", defaultValue: TodaySection.defaultSectionList)
+    public var todaySectionList: [TodaySection] {
+        willSet {
+            objectWillChange.send()
+        }
+    }
+
     @UserDefault("spotlight_index_version", defaultValue: "")
     public var spotlightIndexVersion: String
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/wrappers/UserDefaultWrapper.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/wrappers/UserDefaultWrapper.swift
@@ -50,3 +50,30 @@ public struct UserDefaultEnum<T: RawRepresentable> where T.RawValue == String {
         }
     }
 }
+
+@propertyWrapper
+public struct UserDefaultCodable<T: Codable> {
+    let key: String
+    let defaultValue: T
+
+    init(_ key: String, defaultValue: T) {
+        self.key = key
+        self.defaultValue = defaultValue
+    }
+
+    public var wrappedValue: T {
+        get {
+            if let data = UserDefaults.standard.data(forKey: key) {
+                if let decoded = try? JSONDecoder().decode(T.self, from: data) {
+                    return decoded
+                }
+            }
+            return self.defaultValue
+        }
+        set {
+            if let encoded = try? JSONEncoder().encode(newValue) {
+                UserDefaults.standard.set(encoded, forKey: key)
+            }
+        }
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
@@ -12,7 +12,8 @@ import Backend
 struct Sheet: View {
     enum SheetType: Identifiable {
         case safari(URL), share(content: [Any])
-        case about, rearrange
+        case about
+        case rearrange(viewModel: DashboardViewModel)
         case userListForm(editingList: UserList?)
         case turnipsForm(subManager: SubscriptionManager)
         case subscription(source: SubscribeView.Source, subManager: SubscriptionManager)
@@ -63,9 +64,9 @@ struct Sheet: View {
             return AnyView(SubscribeView(source: source).environmentObject(subManager))
         case .userListForm(let list):
             return AnyView(UserListFormView(editingList: list))
-        case .rearrange:
+        case .rearrange(let viewModel):
             return AnyView(NavigationView {
-                TodaySectionEditView()
+                TodaySectionEditView(viewModel: viewModel)
             }
             .navigationViewStyle(StackNavigationViewStyle()))
         }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayBirthdaysSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayBirthdaysSection.swift
@@ -11,10 +11,10 @@ import Backend
 import UI
 
 struct TodayBirthdaysSection: View {
-    var villagers: [Villager]
+    @ObservedObject private var viewModel = VillagersViewModel()
 
     var headerText: String {
-        villagers.count > 1 ? "Today's Birthdays" : "Today's Birthday"
+        viewModel.todayBirthdays.count > 1 ? "Today's Birthdays" : "Today's Birthday"
     }
     
     private func formattedDate(for villager: Villager) -> Date {
@@ -39,10 +39,10 @@ struct TodayBirthdaysSection: View {
 
     var body: some View {
         Section(header: SectionHeaderView(text: headerText, icon: "gift.fill")) {
-            if villagers.isEmpty {
+            if viewModel.todayBirthdays.isEmpty {
                 RowLoadingView(isLoading: .constant(true))
             } else {
-                ForEach(villagers, id: \.id) { villager in
+                ForEach(viewModel.todayBirthdays, id: \.id) { villager in
                     NavigationLink(destination: VillagerDetailView(villager: villager)) {
                         self.makeCell(for: villager)
                     }
@@ -90,7 +90,7 @@ struct TodayBirthdaysSection_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             List {
-                TodayBirthdaysSection(villagers: [static_villager])
+                TodayBirthdaysSection()
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
@@ -46,7 +46,6 @@ struct TodaySectionEditView: View {
 
     var body: some View {
         List(selection: self.$viewModel.selection) {
-
             Section(header: SectionHeaderView(text: "Drag & Drop to Rearrange", icon: "arrow.up.arrow.down.circle.fill"), footer: self.footer) {
                 ForEach(viewModel.sectionOrder, id: \.name) { section in
                     HStack {
@@ -87,7 +86,6 @@ struct TodaySectionEditView: View {
         VStack(alignment: .leading, spacing: 8) {
             Text("Drag and drop").fontWeight(.bold) + Text(" to re-order sections.")
             Text("Check or un-check").fontWeight(.bold) + Text(" rows to hide sections from the dashboard.")
-            Text("Your top-most section will be the default detail view on iPad and Mac.")
         }
         .padding(.vertical)
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
@@ -7,38 +7,56 @@
 //
 
 import SwiftUI
+import Backend
 
 struct TodaySectionEditView: View {
-    
     @Environment(\.presentationMode) private var presentationMode
+
+    @ObservedObject var viewModel: DashboardViewModel
+
     @State private var editMode = EditMode.active
-    @State private var selection = Set<String>()
-    
-    @State private var sections: [SectionHeaderView] = [
-        SectionHeaderView(text: "New on Nookazon", icon: "cart.fill"),
-        SectionHeaderView(text: "Currently Available", icon: "calendar"),
-        SectionHeaderView(text: "Collection Progress", icon: "chart.pie.fill"),
-        SectionHeaderView(text: "Turnips", icon: "dollarsign.circle.fill"),
-        SectionHeaderView(text: "Today's Tasks", icon: "checkmark.seal.fill"),
-        SectionHeaderView(text: "Events", icon: "flag.fill"),
-        SectionHeaderView(text: "Birthdays", icon: "gift.fill")
+
+    private let textForSectionName = [
+        TodaySection.nameEvents: "Events",
+        TodaySection.nameSpecialCharacters: "Possible visitors",
+        TodaySection.nameCurrentlyAvailable: "Currently Available",
+        TodaySection.nameCollectionProgress: "Collection Progress",
+        TodaySection.nameBirthdays: "Today's Birthdays",
+        TodaySection.nameTurnips: "Turnips",
+        TodaySection.nameSubscribe: "Subscribe",
+        TodaySection.nameMysteryIsland: "Mystery Islands",
+        TodaySection.nameMusic: "Music player",
+        TodaySection.nameTasks: "Today's Tasks",
+        TodaySection.nameNookazon: "New on Nookazon"
     ]
     
-    @State private var hiddenSections: [SectionHeaderView] = []
-        
+    private let iconForSectionName = [
+        TodaySection.nameEvents: "flag.fill",
+        TodaySection.nameSpecialCharacters: "clock",
+        TodaySection.nameCurrentlyAvailable: "calendar",
+        TodaySection.nameCollectionProgress: "chart.pie.fill",
+        TodaySection.nameBirthdays: "gift.fill",
+        TodaySection.nameTurnips: "dollarsign.circle.fill",
+        TodaySection.nameSubscribe: "suit.heart.fill",
+        TodaySection.nameMysteryIsland: "sun.haze.fill",
+        TodaySection.nameMusic: "music.note",
+        TodaySection.nameTasks: "checkmark.seal.fill",
+        TodaySection.nameNookazon: "cart.fill"
+    ]
+
     var body: some View {
-        List(selection: $selection) {
-            
+        List(selection: self.$viewModel.selection) {
+
             Section(header: SectionHeaderView(text: "Drag & Drop to Rearrange", icon: "arrow.up.arrow.down.circle.fill"), footer: self.footer) {
-                ForEach(sections, id: \.text) { section in
+                ForEach(viewModel.sectionOrder, id: \.name) { section in
                     HStack {
-                        Image(systemName: section.icon ?? "")
+                        Image(systemName: self.iconForSectionName[section.name] ?? "")
                             .resizable()
                             .aspectRatio(1, contentMode: .fit)
                             .frame(width: 22)
                             .foregroundColor(Color("ACSecondaryText"))
                         
-                        Text(section.text)
+                        Text(LocalizedStringKey(self.textForSectionName[section.name] ?? ""))
                             .font(.system(.body, design: .rounded))
                         
                         Spacer()
@@ -47,28 +65,8 @@ struct TodaySectionEditView: View {
                 }
                 .onMove(perform: onMove)
             }
-            
-            if hiddenSections.count > 0 {
-                Section(header: SectionHeaderView(text: "Hidden", icon: "eye.slash.fill")) {
-                    ForEach(hiddenSections, id: \.text) { section in
-                        HStack {
-                            Image(systemName: section.icon ?? "")
-                                .resizable()
-                                .aspectRatio(1, contentMode: .fit)
-                                .frame(width: 22)
-                                .foregroundColor(Color("ACSecondaryText"))
-                            
-                            Text(section.text)
-                                .font(.system(.body, design: .rounded))
-                            
-                            Spacer()
-                        }
-                    }
-                    .onMove(perform: onMove)
-                }
-            }
-            
         }
+        .onDisappear(perform: self.viewModel.saveSectionList)
         .listStyle(GroupedListStyle())
         .environment(\.editMode, $editMode)
         .navigationBarTitle("Today Sections")
@@ -95,12 +93,13 @@ struct TodaySectionEditView: View {
     }
     
     private func onMove(source: IndexSet, destination: Int) {
-        sections.move(fromOffsets: source, toOffset: destination)
+        print("Moving \(source.startIndex) to \(destination)")
+        viewModel.sectionOrder.move(fromOffsets: source, toOffset: destination)
     }
 }
 
 struct TodaySectionEditView_Previews: PreviewProvider {
     static var previews: some View {
-        TodaySectionEditView()
+        TodaySectionEditView(viewModel: DashboardViewModel())
     }
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
@@ -10,12 +10,12 @@ import SwiftUI
 import Backend
 
 struct TodaySectionView: View {
+    @EnvironmentObject var uiState: UIState
+    
     let section: TodaySection
-    let viewModel: DashboardViewModel
+    
+    @ObservedObject var viewModel: DashboardViewModel
     @Binding var selectedSheet: Sheet.SheetType?
-    let villagers: [Villager]
-    let turnipPredictionsService: TurnipPredictionsService
-    let uiState: UIState
 
 
     var body: some View {
@@ -37,9 +37,9 @@ struct TodaySectionView: View {
             case TodaySection.nameCollectionProgress:
                 return AnyView(TodayCollectionProgressSection(viewModel: viewModel, sheet: $selectedSheet))
             case TodaySection.nameBirthdays:
-                return AnyView(TodayBirthdaysSection(villagers: villagers))
+                return AnyView(TodayBirthdaysSection())
             case TodaySection.nameTurnips:
-                return AnyView(TodayTurnipSection(predictions: turnipPredictionsService.predictions)
+                return AnyView(TodayTurnipSection()
                     .onTapGesture {
                         self.uiState.selectedTab = .turnips
                 })

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
@@ -1,0 +1,61 @@
+//
+//  TodaySectionView.swift
+//  ACHNBrowserUI
+//
+//  Created by theunimpossible on 5/24/20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+import Backend
+
+struct TodaySectionView: View {
+    let section: TodaySection
+    let viewModel: DashboardViewModel
+    @Binding var selectedSheet: Sheet.SheetType?
+    let villagers: [Villager]
+    let turnipPredictionsService: TurnipPredictionsService
+    let uiState: UIState
+
+
+    var body: some View {
+        makeView()
+    }
+
+    func makeView() -> some View {
+       if !section.enabled {
+            return AnyView(EmptyView())
+        }
+
+        switch(section.name) {
+            case TodaySection.nameEvents:
+                return AnyView(TodayEventsSection())
+            case TodaySection.nameSpecialCharacters:
+                return AnyView(TodaySpecialCharactersSection())
+            case TodaySection.nameCurrentlyAvailable:
+                return AnyView(TodayCurrentlyAvailableSection(viewModel: viewModel))
+            case TodaySection.nameCollectionProgress:
+                return AnyView(TodayCollectionProgressSection(viewModel: viewModel, sheet: $selectedSheet))
+            case TodaySection.nameBirthdays:
+                return AnyView(TodayBirthdaysSection(villagers: villagers))
+            case TodaySection.nameTurnips:
+                return AnyView(TodayTurnipSection(predictions: turnipPredictionsService.predictions)
+                    .onTapGesture {
+                        self.uiState.selectedTab = .turnips
+                })
+            case TodaySection.nameSubscribe:
+                return AnyView(TodaySubscribeSection(sheet: $selectedSheet))
+            case TodaySection.nameMysteryIsland:
+                return AnyView(TodayMysteryIslandsSection())
+            case TodaySection.nameMusic:
+                return AnyView(TodayMusicPlayerSection())
+            case TodaySection.nameTasks:
+                return AnyView(TodayTasksSection())
+            case TodaySection.nameNookazon:
+                return AnyView(TodayNookazonSection(sheet: $selectedSheet, viewModel: viewModel))
+            default:
+                return AnyView(EmptyView())
+        }
+
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayTurnipSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayTurnipSection.swift
@@ -10,7 +10,7 @@ import SwiftUI
 import Backend
 
 struct TodayTurnipSection: View {
-    let predictions: TurnipPredictions?
+    @EnvironmentObject private var turnipService: TurnipPredictionsService
     
     var isSunday: Bool {
         Calendar.current.component(.weekday, from: Date()) == 1
@@ -27,14 +27,14 @@ struct TodayTurnipSection: View {
                 Group {
                     if isSunday {
                         Text("Today is sunday, don't forget to buy more turnips and fill your buy price.")
-                    } else if predictions?.todayAverages == nil || predictions?.todayAverages?.isEmpty == true {
+                    } else if turnipService.predictions?.todayAverages == nil || turnipService.predictions?.todayAverages?.isEmpty == true {
                         Text("Your turnips predictions will be displayed here once you fill in some prices.")
                     }  else {
                         Text("Today's average price should be around ")
-                            + Text("\(predictions!.todayAverages![0])")
+                            + Text("\(turnipService.predictions!.todayAverages![0])")
                                 .foregroundColor(Color("ACSecondaryText"))
                             + Text(" in the morning, and ")
-                            + Text("\(predictions!.todayAverages![1])")
+                            + Text("\(turnipService.predictions!.todayAverages![1])")
                                 .foregroundColor(Color("ACSecondaryText"))
                             + Text(" this afternoon.")
                     }
@@ -53,7 +53,7 @@ struct TodayTurnipSection_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             List {
-                TodayTurnipSection(predictions: TurnipPredictionsService.shared.predictions)
+                TodayTurnipSection()
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
@@ -19,11 +19,10 @@ struct TodayView: View {
     @EnvironmentObject private var collection: UserCollection
     @EnvironmentObject private var subManager: SubscriptionManager
     @EnvironmentObject private var items: Items
-    @ObservedObject private var userDefaults = AppUserDefaults.shared
-    @ObservedObject private var viewModel = DashboardViewModel()
-    @ObservedObject private var villagersViewModel = VillagersViewModel()
-    @ObservedObject private var turnipsPredictionsService = TurnipPredictionsService.shared
+    @EnvironmentObject private var userDefaults: AppUserDefaults
     
+    @ObservedObject private var viewModel = DashboardViewModel()
+
     @State private var selectedSheet: Sheet.SheetType?
     @State private var showWhatsNew: Bool = false
         
@@ -56,7 +55,9 @@ struct TodayView: View {
                 Group {
                     ForEach(viewModel.sectionOrder, id: \.self) { section in
                         // The required data could be refactored into the model.
-                        TodaySectionView(section: section, viewModel: self.viewModel, selectedSheet: self.$selectedSheet, villagers: self.villagersViewModel.todayBirthdays, turnipPredictionsService: self.turnipsPredictionsService, uiState: self.uiState)
+                        TodaySectionView(section: section,
+                                         viewModel: self.viewModel,
+                                         selectedSheet: self.$selectedSheet)
                     }
 
                     self.arrangeSectionsButton

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
@@ -54,21 +54,12 @@ struct TodayView: View {
                 }
 
                 Group {
-                    TodayEventsSection()
-                    TodaySpecialCharactersSection()
-                    TodayCurrentlyAvailableSection(viewModel: viewModel)
-                    TodayCollectionProgressSection(viewModel: viewModel, sheet: $selectedSheet)
-                    TodayBirthdaysSection(villagers: villagersViewModel.todayBirthdays)
-                    TodayTurnipSection(predictions: turnipsPredictionsService.predictions)
-                        .onTapGesture {
-                            self.uiState.selectedTab = .turnips
+                    ForEach(viewModel.sectionOrder, id: \.self) { section in
+                        // The required data could be refactored into the model.
+                        TodaySectionView(section: section, viewModel: self.viewModel, selectedSheet: self.$selectedSheet, villagers: self.villagersViewModel.todayBirthdays, turnipPredictionsService: self.turnipsPredictionsService, uiState: self.uiState)
                     }
-                    TodayTasksSection()
-                    // TodayNookazonSection(sheet: $selectedSheet, viewModel: viewModel)
-                    TodaySubscribeSection(sheet: $selectedSheet)
-                    TodayMusicPlayerSection()
-                    TodayMysteryIslandsSection()
-                    // self.arrangeSectionsButton
+
+                    self.arrangeSectionsButton
                 }
             }
             .listStyle(GroupedListStyle())
@@ -81,10 +72,10 @@ struct TodayView: View {
                                activeBugs: bugsAvailable)
         }
     }
-            
+
     var arrangeSectionsButton: some View {
         Section {
-            Button(action: { self.selectedSheet = .rearrange }) {
+            Button(action: { self.selectedSheet = .rearrange(viewModel: self.viewModel) }) {
                 HStack {
                     Image(systemName: "arrow.up.arrow.down")
                         .font(.system(.body, design: .rounded))


### PR DESCRIPTION
Hello, I took a stab at issue #115: Organizing Dashboard Widgets as it seemed like a fun task which you were asking for some help on. You can now check/uncheck the rows and move things around. I added support for saving the state to the user defaults so that it reloads with the app.

The only weirdness was that I needed to wrap everything in another to keep the ForEach stable. I think we could refactor the TodayView to push more data to the model.

I hardcoded the subscribe button to not be removable - but I feel like that decision could be left to you to change.

I'm still learning app development so I'd appreciate constructive feedback if you have it :)

Cheers!