### PR TITLE
fix(Dashboard Today Widgets): reorder works without crash

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
@@ -7,42 +7,43 @@
 
 import Foundation
 
-public struct TodaySection: Codable, Hashable, Equatable {
-    public static let nameEvents = "events"
-    public static let nameSpecialCharacters = "specialCharacters"
-    public static let nameCurrentlyAvailable = "currentlyAvailable"
-    public static let nameCollectionProgress = "collectionProgress"
-    public static let nameBirthdays = "birthdays"
-    public static let nameTurnips = "turnips"
-    public static let nameSubscribe = "subscribe"
-    public static let nameMysteryIsland = "mysteryIsland"
-    public static let nameMusic = "music"
-    public static let nameTasks = "tasks"
-    public static let nameNookazon = "nookazon"
+public struct TodaySection: Codable, Hashable, Identifiable {
+    public let name: Name
+    public var enabled: Bool
+    public var id: Name { name }
 
-    public static let defaultSectionList: [TodaySection] = [
-        TodaySection(name: Self.nameEvents, enabled: true),
-        TodaySection(name: Self.nameSpecialCharacters, enabled: true),
-        TodaySection(name: Self.nameCurrentlyAvailable, enabled: true),
-        TodaySection(name: Self.nameCollectionProgress, enabled: true),
-        TodaySection(name: Self.nameBirthdays, enabled: true),
-        TodaySection(name: Self.nameTurnips, enabled: true),
-        TodaySection(name: Self.nameTasks, enabled: true),
-        TodaySection(name: Self.nameSubscribe, enabled: true),
-        TodaySection(name: Self.nameMusic, enabled: true),
-        //TodaySection(name: Self.nameNookazon, enabled: true)
-        TodaySection(name: Self.nameMysteryIsland, enabled: true),
-    ]
-    
-    public static func == (lhs: TodaySection, rhs: TodaySection) -> Bool {
-        return lhs.name == rhs.name
-    }
-
-    public init(name: String, enabled: Bool) {
+    public init(name: Name, enabled: Bool) {
         self.name = name
         self.enabled = enabled
     }
+}
 
-    public let name: String
-    public var enabled: Bool
+extension TodaySection {
+    public enum Name: String, Codable {
+        case events
+        case specialCharacters
+        case currentlyAvailable
+        case collectionProgress
+        case birthdays
+        case turnips
+        case subscribe
+        case mysteryIsland
+        case music
+        case tasks
+        case nookazon
+    }
+
+    public static let defaultSectionList: [TodaySection] = [
+        TodaySection(name: .events, enabled: true),
+        TodaySection(name: .specialCharacters, enabled: true),
+        TodaySection(name: .currentlyAvailable, enabled: true),
+        TodaySection(name: .collectionProgress, enabled: true),
+        TodaySection(name: .birthdays, enabled: true),
+        TodaySection(name: .turnips, enabled: true),
+        TodaySection(name: .tasks, enabled: true),
+        TodaySection(name: .subscribe, enabled: true),
+        TodaySection(name: .music, enabled: true),
+        //TodaySection(name: .nameNookazon, enabled: true)
+        TodaySection(name: .mysteryIsland, enabled: true),
+    ]
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
@@ -15,7 +15,7 @@ class DashboardViewModel: ObservableObject {
     @Published var island: Island?
     @Published var sectionOrder: [TodaySection]
     
-    public var selection = Set<String>()
+    public var selection = Set<TodaySection.Name>()
     private var listingCancellable: AnyCancellable?
     private var islandCancellable: AnyCancellable?
     
@@ -25,9 +25,8 @@ class DashboardViewModel: ObservableObject {
     }
 
     public func saveSectionList() {
-        for index in 0..<sectionOrder.count {
-            let name = sectionOrder[index].name
-            if !selection.contains(name) && name != TodaySection.nameSubscribe {
+        for (index, section) in sectionOrder.enumerated() {
+            if !selection.contains(section.name) && section.name != .subscribe {
                 sectionOrder[index].enabled = false
             } else {
                 sectionOrder[index].enabled = true
@@ -43,11 +42,7 @@ class DashboardViewModel: ObservableObject {
                 sectionOrder.append(TodaySection(name: section.name, enabled: true))
             }
         }
-        sectionOrder.forEach { (section) in
-            if section.enabled {
-                selection.insert(section.name)
-            }
-        }
+        selection = Set(sectionOrder.filter(\.enabled).map(\.name))
     }
         
     func fetchListings() {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import Backend
+import Combine
 
 struct TodaySectionEditView: View {
     @Environment(\.presentationMode) private var presentationMode
@@ -16,34 +17,6 @@ struct TodaySectionEditView: View {
 
     @State private var editMode = EditMode.active
 
-    private let textForSectionName = [
-        TodaySection.nameEvents: "Events",
-        TodaySection.nameSpecialCharacters: "Possible visitors",
-        TodaySection.nameCurrentlyAvailable: "Currently Available",
-        TodaySection.nameCollectionProgress: "Collection Progress",
-        TodaySection.nameBirthdays: "Today's Birthdays",
-        TodaySection.nameTurnips: "Turnips",
-        TodaySection.nameSubscribe: "Subscribe",
-        TodaySection.nameMysteryIsland: "Mystery Islands",
-        TodaySection.nameMusic: "Music player",
-        TodaySection.nameTasks: "Today's Tasks",
-        TodaySection.nameNookazon: "New on Nookazon"
-    ]
-    
-    private let iconForSectionName = [
-        TodaySection.nameEvents: "flag.fill",
-        TodaySection.nameSpecialCharacters: "clock",
-        TodaySection.nameCurrentlyAvailable: "calendar",
-        TodaySection.nameCollectionProgress: "chart.pie.fill",
-        TodaySection.nameBirthdays: "gift.fill",
-        TodaySection.nameTurnips: "dollarsign.circle.fill",
-        TodaySection.nameSubscribe: "suit.heart.fill",
-        TodaySection.nameMysteryIsland: "sun.haze.fill",
-        TodaySection.nameMusic: "music.note",
-        TodaySection.nameTasks: "checkmark.seal.fill",
-        TodaySection.nameNookazon: "cart.fill"
-    ]
-
     var body: some View {
         List(selection: self.$viewModel.selection) {
             Section(header: SectionHeaderView(text: "Drag & Drop to Rearrange",
@@ -51,13 +24,13 @@ struct TodaySectionEditView: View {
                     footer: self.footer) {
                 ForEach(viewModel.sectionOrder, id: \.name) { section in
                     HStack {
-                        Image(systemName: self.iconForSectionName[section.name] ?? "")
+                        Image(systemName: section.iconName)
                             .resizable()
                             .aspectRatio(1, contentMode: .fit)
                             .frame(width: 22)
-                            .foregroundColor(Color("ACSecondaryText"))
+                            .foregroundColor(.acSecondaryText)
                         
-                        Text(LocalizedStringKey(self.textForSectionName[section.name] ?? ""))
+                        Text(LocalizedStringKey(section.sectionName))
                             .font(.system(.body, design: .rounded))
                         
                         Spacer()
@@ -94,6 +67,40 @@ struct TodaySectionEditView: View {
     
     private func onMove(source: IndexSet, destination: Int) {
         viewModel.sectionOrder.move(fromOffsets: source, toOffset: destination)
+    }
+}
+
+extension TodaySection {
+    var sectionName: String {
+        switch name {
+        case .events: return "Events"
+        case .specialCharacters: return "Possible visitors"
+        case .currentlyAvailable: return "Currently Available"
+        case .collectionProgress: return "Collection Progress"
+        case .birthdays: return "Today's Birthdays"
+        case .turnips: return "Turnips"
+        case .subscribe: return "Subscribe"
+        case .mysteryIsland: return "Mystery Islands"
+        case .music: return "Music player"
+        case .tasks: return "Today's Tasks"
+        case .nookazon: return "New on Nookazon"
+        }
+    }
+
+    var iconName: String {
+        switch name {
+        case .events: return "flag.fill"
+        case .specialCharacters: return "clock"
+        case .currentlyAvailable: return "calendar"
+        case .collectionProgress: return "chart.pie.fill"
+        case .birthdays: return "gift.fill"
+        case .turnips: return "dollarsign.circle.fill"
+        case .subscribe: return "suit.heart.fill"
+        case .mysteryIsland: return "sun.haze.fill"
+        case .music: return "music.note"
+        case .tasks: return "checkmark.seal.fill"
+        case .nookazon: return "cart.fill"
+        }
     }
 }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
@@ -23,39 +23,36 @@ struct TodaySectionView: View {
     }
 
     func makeView() -> some View {
-       if !section.enabled {
+        if !section.enabled {
             return AnyView(EmptyView())
         }
 
         switch(section.name) {
-            case TodaySection.nameEvents:
-                return AnyView(TodayEventsSection())
-            case TodaySection.nameSpecialCharacters:
-                return AnyView(TodaySpecialCharactersSection())
-            case TodaySection.nameCurrentlyAvailable:
-                return AnyView(TodayCurrentlyAvailableSection(viewModel: viewModel))
-            case TodaySection.nameCollectionProgress:
-                return AnyView(TodayCollectionProgressSection(viewModel: viewModel, sheet: $selectedSheet))
-            case TodaySection.nameBirthdays:
-                return AnyView(TodayBirthdaysSection())
-            case TodaySection.nameTurnips:
-                return AnyView(TodayTurnipSection()
-                    .onTapGesture {
-                        self.uiState.selectedTab = .turnips
-                })
-            case TodaySection.nameSubscribe:
-                return AnyView(TodaySubscribeSection(sheet: $selectedSheet))
-            case TodaySection.nameMysteryIsland:
-                return AnyView(TodayMysteryIslandsSection())
-            case TodaySection.nameMusic:
-                return AnyView(TodayMusicPlayerSection())
-            case TodaySection.nameTasks:
-                return AnyView(TodayTasksSection())
-            case TodaySection.nameNookazon:
-                return AnyView(TodayNookazonSection(sheet: $selectedSheet, viewModel: viewModel))
-            default:
-                return AnyView(EmptyView())
+        case .events:
+            return AnyView(TodayEventsSection())
+        case .specialCharacters:
+            return AnyView(TodaySpecialCharactersSection())
+        case .currentlyAvailable:
+            return AnyView(TodayCurrentlyAvailableSection(viewModel: viewModel))
+        case .collectionProgress:
+            return AnyView(TodayCollectionProgressSection(viewModel: viewModel, sheet: $selectedSheet))
+        case .birthdays:
+            return AnyView(TodayBirthdaysSection())
+        case .turnips:
+            return AnyView(TodayTurnipSection()
+                .onTapGesture {
+                    self.uiState.selectedTab = .turnips
+            })
+        case .subscribe:
+            return AnyView(TodaySubscribeSection(sheet: $selectedSheet))
+        case .mysteryIsland:
+            return AnyView(TodayMysteryIslandsSection())
+        case .music:
+            return AnyView(TodayMusicPlayerSection())
+        case .tasks:
+            return AnyView(TodayTasksSection())
+        case .nookazon:
+            return AnyView(TodayNookazonSection(sheet: $selectedSheet, viewModel: viewModel))
         }
-
     }
 }


### PR DESCRIPTION
* Sometimes a crash could happen (especially when you try to reorder
Tasks to the first elements in the list)