### PR TITLE
Add Custom Chores and To-Dos

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
+++ b/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
@@ -180,6 +180,13 @@
 		AE2D7EFC247E9726006C1F1A /* DesignListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D7EFB247E9726006C1F1A /* DesignListView.swift */; };
 		AE2D7EFE247EAF05006C1F1A /* CrittersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D7EFD247EAF05006C1F1A /* CrittersListView.swift */; };
 		AE2D7F01247EB2A8006C1F1A /* MessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2D7F00247EB2A8006C1F1A /* MessageView.swift */; };
+		AE38E4A72482D772000DFED3 /* ChoreListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE38E4A62482D772000DFED3 /* ChoreListViewModel.swift */; };
+		AE51C2E1247F39B900F074EC /* ChoreListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE51C2E0247F39B900F074EC /* ChoreListView.swift */; };
+		AE51C2E324801D5D00F074EC /* ChoreListRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE51C2E224801D5D00F074EC /* ChoreListRowView.swift */; };
+		AE51C2E7248117EC00F074EC /* ChoreFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE51C2E6248117EC00F074EC /* ChoreFormView.swift */; };
+		AE51C2E92481185900F074EC /* ChoreFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE51C2E82481185900F074EC /* ChoreFormViewModel.swift */; };
+		AE96184824816B7200CC073C /* TodayChoresSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE96184724816B7200CC073C /* TodayChoresSection.swift */; };
+		AE96184A2482B1F300CC073C /* TodayChoresSectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE9618492482B1F300CC073C /* TodayChoresSectionViewModel.swift */; };
 		AEEEC4C6247AB1F400894C02 /* DesignRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEEC4C5247AB1F400894C02 /* DesignRowView.swift */; };
 		FA0EC271247B77E400447D7E /* VillagersSortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0EC270247B77E400447D7E /* VillagersSortView.swift */; };
 /* End PBXBuildFile section */
@@ -364,6 +371,13 @@
 		AE2D7EFB247E9726006C1F1A /* DesignListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignListView.swift; sourceTree = "<group>"; };
 		AE2D7EFD247EAF05006C1F1A /* CrittersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrittersListView.swift; sourceTree = "<group>"; };
 		AE2D7F00247EB2A8006C1F1A /* MessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageView.swift; sourceTree = "<group>"; };
+		AE38E4A62482D772000DFED3 /* ChoreListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreListViewModel.swift; sourceTree = "<group>"; };
+		AE51C2E0247F39B900F074EC /* ChoreListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreListView.swift; sourceTree = "<group>"; };
+		AE51C2E224801D5D00F074EC /* ChoreListRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreListRowView.swift; sourceTree = "<group>"; };
+		AE51C2E6248117EC00F074EC /* ChoreFormView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreFormView.swift; sourceTree = "<group>"; };
+		AE51C2E82481185900F074EC /* ChoreFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChoreFormViewModel.swift; sourceTree = "<group>"; };
+		AE96184724816B7200CC073C /* TodayChoresSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayChoresSection.swift; sourceTree = "<group>"; };
+		AE9618492482B1F300CC073C /* TodayChoresSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayChoresSectionViewModel.swift; sourceTree = "<group>"; };
 		AEEEC4C5247AB1F400894C02 /* DesignRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignRowView.swift; sourceTree = "<group>"; };
 		FA0EC270247B77E400447D7E /* VillagersSortView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VillagersSortView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -399,21 +413,22 @@
 		024363CF2465E7FD006A37A0 /* todayDashboard */ = {
 			isa = PBXGroup;
 			children = (
-				024363D22465EA14006A37A0 /* TodayView.swift */,
-				024363D32465EA14006A37A0 /* TodaySectionEditView.swift */,
 				024363D52465EA15006A37A0 /* TodayBirthdaysSection.swift */,
+				AE96184724816B7200CC073C /* TodayChoresSection.swift */,
 				024363D72465EA15006A37A0 /* TodayCollectionProgressSection.swift */,
 				024363D02465EA14006A37A0 /* TodayCurrentlyAvailableSection.swift */,
 				024363D42465EA14006A37A0 /* TodayEventsSection.swift */,
+				696B4549247A633D00E16252 /* TodayMusicPlayerSection.swift */,
+				69157B6D247121ED005B9002 /* TodayMysteryIslandsSection.swift */,
+				693E2BC3246689C500B85CB8 /* TodayNookazonSection.swift */,
+				024363D32465EA14006A37A0 /* TodaySectionEditView.swift */,
+				157C03E6247AE56600568917 /* TodaySectionView.swift */,
+				693352832473C4B5007EF9AB /* TodaySpecialCharactersSection.swift */,
+				693E2BC924669D2800B85CB8 /* TodaySubscribeSection.swift */,
 				024363D62465EA15006A37A0 /* TodayTasksSection.swift */,
 				024363D12465EA14006A37A0 /* TodayTurnipSection.swift */,
-				693E2BC3246689C500B85CB8 /* TodayNookazonSection.swift */,
+				024363D22465EA14006A37A0 /* TodayView.swift */,
 				693E2BC524668D8E00B85CB8 /* TodayWhatsNewSection.swift */,
-				693E2BC924669D2800B85CB8 /* TodaySubscribeSection.swift */,
-				69157B6D247121ED005B9002 /* TodayMysteryIslandsSection.swift */,
-				696B4549247A633D00E16252 /* TodayMusicPlayerSection.swift */,
-				693352832473C4B5007EF9AB /* TodaySpecialCharactersSection.swift */,
-				157C03E6247AE56600568917 /* TodaySectionView.swift */,
 			);
 			path = todayDashboard;
 			sourceTree = "<group>";
@@ -664,6 +679,7 @@
 				69BEA981243E608E00F02C61 /* shared */,
 				693E7292245D833F00CD26F4 /* subscription */,
 				024363CF2465E7FD006A37A0 /* todayDashboard */,
+				AE51C2DF247F399300F074EC /* chores */,
 				687B5765244A02E400C1E86F /* turnips */,
 				69875F5324654EA400B1D46C /* userLists */,
 				697E63F32449A488008FB710 /* villagers */,
@@ -675,6 +691,8 @@
 			isa = PBXGroup;
 			children = (
 				6941F3872452BDDD00EC2E02 /* CategoriesSearchViewModel.swift */,
+				AE51C2E82481185900F074EC /* ChoreFormViewModel.swift */,
+				AE38E4A62482D772000DFED3 /* ChoreListViewModel.swift */,
 				AE2D7EF9247E8CBD006C1F1A /* CollectionMoreDetailViewModel.swift */,
 				69867DF0247C136900C6A759 /* CollectionProgressRowViewModel.swift */,
 				693E0B1C244C315B00D20E46 /* DashboardViewModel.swift */,
@@ -682,6 +700,7 @@
 				AE0B5B5D247B14120075CF16 /* DesignRowViewModel.swift */,
 				68DFFFAC24492D7F00DEA07F /* ItemDetailViewModel.swift */,
 				69AF8C6C243E2A18001DD9CB /* ItemsViewModel.swift */,
+				AE9618492482B1F300CC073C /* TodayChoresSectionViewModel.swift */,
 				68BA5829244B693300B53811 /* TurnipsViewModel.swift */,
 				69875F5A24655AF000B1D46C /* UserListDetailViewModel.swift */,
 				69875F5624654F7100B1D46C /* UserListFormViewModel.swift */,
@@ -869,6 +888,16 @@
 				AE2D7F00247EB2A8006C1F1A /* MessageView.swift */,
 			);
 			path = message;
+			sourceTree = "<group>";
+		};
+		AE51C2DF247F399300F074EC /* chores */ = {
+			isa = PBXGroup;
+			children = (
+				AE51C2E6248117EC00F074EC /* ChoreFormView.swift */,
+				AE51C2E224801D5D00F074EC /* ChoreListRowView.swift */,
+				AE51C2E0247F39B900F074EC /* ChoreListView.swift */,
+			);
+			path = chores;
 			sourceTree = "<group>";
 		};
 		AEEEC4C4247AB1B100894C02 /* design */ = {
@@ -1082,7 +1111,9 @@
 				69157B942471A5A1005B9002 /* ActivityControllerView.swift in Sources */,
 				69157B952471A5A1005B9002 /* ItemsCrosslineSectionView.swift in Sources */,
 				69867DF1247C136900C6A759 /* CollectionProgressRowViewModel.swift in Sources */,
+				AE51C2E7248117EC00F074EC /* ChoreFormView.swift in Sources */,
 				69157B962471A5A1005B9002 /* TurnipsChartTopLegendView.swift in Sources */,
+				AE38E4A72482D772000DFED3 /* ChoreListViewModel.swift in Sources */,
 				69157B972471A5A1005B9002 /* TurnipsChartView.swift in Sources */,
 				696B454C247A948A00E16252 /* MusicPlayerManager.swift in Sources */,
 				69157B982471A5A1005B9002 /* ActiveCrittersView.swift in Sources */,
@@ -1104,6 +1135,7 @@
 				69157BA52471A5A1005B9002 /* AdaptsToSoftwareKeyboard.swift in Sources */,
 				AE2D7EF8247E8C9A006C1F1A /* CollectionMoreDetailView.swift in Sources */,
 				69157BA62471A5A1005B9002 /* CollectionProgressRow.swift in Sources */,
+				AE51C2E92481185900F074EC /* ChoreFormViewModel.swift in Sources */,
 				69157BA72471A5A1005B9002 /* TurnipIslandRow.swift in Sources */,
 				69157BA82471A5A1005B9002 /* CategoryHeaderView.swift in Sources */,
 				69157BA92471A5A1005B9002 /* ItemDetailSource.swift in Sources */,
@@ -1129,6 +1161,8 @@
 				69157BBD2471A5A1005B9002 /* Text.swift in Sources */,
 				69CCD28C247DA4D100DF381B /* ItemStyleBadgeView.swift in Sources */,
 				69157BBE2471A5A1005B9002 /* ItemsListView.swift in Sources */,
+				AE96184824816B7200CC073C /* TodayChoresSection.swift in Sources */,
+				AE51C2E1247F39B900F074EC /* ChoreListView.swift in Sources */,
 				69157BBF2471A5A1005B9002 /* ItemDetailView.swift in Sources */,
 				69157BC02471A5A1005B9002 /* TodayBirthdaysSection.swift in Sources */,
 				AE2D7EFC247E9726006C1F1A /* DesignListView.swift in Sources */,
@@ -1144,12 +1178,14 @@
 				69157BC92471A5A1005B9002 /* TurnipsChartGrid.swift in Sources */,
 				69157BCA2471A5A1005B9002 /* CollectionRowView.swift in Sources */,
 				AE0B5B5C247AD7590075CF16 /* DesignFormViewModel.swift in Sources */,
+				AE51C2E324801D5D00F074EC /* ChoreListRowView.swift in Sources */,
 				69157BCB2471A5A1005B9002 /* SearchField.swift in Sources */,
 				69157BCC2471A5A1005B9002 /* CollectionProgressDetailView.swift in Sources */,
 				69157BCD2471A5A1005B9002 /* AppIconPickerView.swift in Sources */,
 				69157BCE2471A5A1005B9002 /* LikeButtonView.swift in Sources */,
 				69157BCF2471A5A1005B9002 /* CalendarView.swift in Sources */,
 				69157BD02471A5A1005B9002 /* AboutView.swift in Sources */,
+				AE96184A2482B1F300CC073C /* TodayChoresSectionViewModel.swift in Sources */,
 				69157BD12471A5A1005B9002 /* TurnipsViewModel.swift in Sources */,
 				69157BD22471A5A1005B9002 /* TodayWhatsNewSection.swift in Sources */,
 				69157BD42471A5A1005B9002 /* EventsDescription.swift in Sources */,

--- a/ACHNBrowserUI/ACHNBrowserUI/AppDelegate.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/AppDelegate.swift
@@ -29,4 +29,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         UserCollection.shared.reloadFromCloudKit()
     }
 }
-

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/environments/UserCollection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/environments/UserCollection.swift
@@ -22,6 +22,7 @@ public class UserCollection: ObservableObject {
     @Published public var lists: [UserList] = []
     @Published public var designs: [Design] = []
     @Published public var dailyTasks = DailyTasks()
+    @Published public var chores: [Chore] = []
     
     @Published public var isCloudEnabled = true
     @Published public var isSynched = false
@@ -35,6 +36,7 @@ public class UserCollection: ObservableObject {
         let lists: [UserList]?
         let dailyTasks: DailyTasks?
         let designs: [Design]?
+        let chores: [Chore]?
     }
     
     private let filePath: URL
@@ -215,8 +217,33 @@ public class UserCollection: ObservableObject {
         save()
     }
 
-    public func deleteDesign(at design: Int) {
-        designs.remove(at: design)
+    public func deleteDesign(at index: Int) {
+        designs.remove(at: index)
+        save()
+    }
+
+    // MARK: - Chores
+
+    public func addChore(_ task: Chore) {
+        chores.append(task)
+        save()
+    }
+
+    public func deleteChore(at index: Int) {
+        chores.remove(at: index)
+        save()
+    }
+
+    public func toggleChore(_ task: Chore) {
+        let index = chores.firstIndex(where: { $0.id == task.id })!
+        chores[index].isFinished.toggle()
+        save()
+    }
+
+    public func resetChores() {
+        for index in 0..<chores.count {
+            chores[index].isFinished = false
+        }
         save()
     }
 
@@ -311,7 +338,8 @@ public class UserCollection: ObservableObject {
                                           critters: weakself.critters,
                                           lists: weakself.lists,
                                           dailyTasks: weakself.dailyTasks,
-                                          designs: weakself.designs)
+                                          designs: weakself.designs,
+                                          chores: weakself.chores)
                 let data = try weakself.encoder.encode(savedData)
                 try data.write(to: weakself.filePath, options: .atomicWrite)
                 
@@ -340,6 +368,7 @@ public class UserCollection: ObservableObject {
                 self.lists = savedData.lists ?? []
                 self.dailyTasks = savedData.dailyTasks ?? DailyTasks()
                 self.designs = savedData.designs ?? []
+                self.chores = savedData.chores ?? []
                 return true
             } catch {
                 return false
@@ -357,6 +386,7 @@ public class UserCollection: ObservableObject {
             self.lists = []
             self.dailyTasks = DailyTasks()
             self.designs = []
+            self.chores = []
             save()
             return true
         } catch {

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/environments/UserCollection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/environments/UserCollection.swift
@@ -235,7 +235,7 @@ public class UserCollection: ObservableObject {
     }
 
     public func toggleChore(_ task: Chore) {
-        let index = chores.firstIndex(where: { $0.id == task.id })!
+        guard let index = chores.firstIndex(of: task) else { return }
         chores[index].isFinished.toggle()
         save()
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/Chore.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/Chore.swift
@@ -1,0 +1,27 @@
+//
+//  File.swift
+//
+//  Created by Otavio Cordeiro on 28.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import Foundation
+
+public struct Chore: Codable, Identifiable, Hashable, Equatable {
+    public let id = UUID()
+    public var title: String = ""
+    public var description: String = ""
+    public var isFinished: Bool = false
+
+    public init(title: String = "", description: String = "", isFinished: Bool = false) {
+        self.title = title
+        self.description = description
+        self.isFinished = isFinished
+    }
+
+    // MARK: - Equatable
+
+    public static func == (lhs: Chore, rhs: Chore) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/TodaySection.swift
@@ -30,6 +30,7 @@ extension TodaySection {
         case mysteryIsland
         case music
         case tasks
+        case chores
         case nookazon
     }
 
@@ -41,6 +42,7 @@ extension TodaySection {
         TodaySection(name: .birthdays, enabled: true),
         TodaySection(name: .turnips, enabled: true),
         TodaySection(name: .tasks, enabled: true),
+        TodaySection(name: .chores, enabled: true),
         TodaySection(name: .subscribe, enabled: true),
         TodaySection(name: .music, enabled: true),
         //TodaySection(name: .nameNookazon, enabled: true)

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreFormViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreFormViewModel.swift
@@ -1,0 +1,33 @@
+//
+//  ChoreFormViewModel.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 29.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import Backend
+import Combine
+
+class ChoreFormViewModel: ObservableObject {
+
+    // MARK: - Properties
+
+    @Published var chore: Chore
+
+    // MARK: - Life cycle
+
+    init(chore: Chore?) {
+        if let chore = chore {
+            self.chore = chore
+        } else {
+            self.chore = Chore()
+        }
+    }
+
+    // MARK: - Public
+
+    func save() {
+        UserCollection.shared.addChore(chore)
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreFormViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreFormViewModel.swift
@@ -18,11 +18,7 @@ class ChoreFormViewModel: ObservableObject {
     // MARK: - Life cycle
 
     init(chore: Chore?) {
-        if let chore = chore {
-            self.chore = chore
-        } else {
-            self.chore = Chore()
-        }
+        self.chore = chore ?? Chore()
     }
 
     // MARK: - Public

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreListViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ChoreListViewModel.swift
@@ -1,0 +1,55 @@
+//
+//  ChoreListViewModel.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 30.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import Backend
+import Combine
+import SwiftUI
+
+final class ChoreListViewModel: ObservableObject {
+
+    // MARK: - Public properties
+
+    @Published var chores: [Chore] = []
+
+    var shouldShowResetButton: Bool {
+        !chores.filter { $0.isFinished == true }.isEmpty
+    }
+
+    var shouldShowDescriptionView: Bool {
+        chores.isEmpty
+    }
+
+    // MARK: - Private properties
+
+    @ObservedObject private var userCollection: UserCollection
+    private var cancellable: AnyCancellable?
+
+    // MARK: - Life cycle
+
+    init(userCollection: UserCollection = .shared) {
+        self.userCollection = userCollection
+
+        cancellable = userCollection.$chores
+            .receive(on: DispatchQueue.main)
+            .sink { chores in
+                self.chores = chores
+        }
+    }
+
+    func toggleChore(_ chore: Chore) {
+        userCollection.toggleChore(chore)
+    }
+
+    func deleteChore(at index: Int) {
+        userCollection.deleteChore(at: index)
+    }
+
+    func resetChores() {
+        userCollection.resetChores()
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/TodayChoresSectionViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/TodayChoresSectionViewModel.swift
@@ -1,0 +1,43 @@
+//
+//  TodayChoresSectionViewModel.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 30.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import Backend
+import Combine
+import SwiftUI
+
+final class TodayChoresSectionViewModel: ObservableObject {
+
+    // MARK: - Public properties
+
+    @Published var chores: [Chore] = []
+
+    var totalChoresCount: Int {
+        chores.count
+    }
+
+    var completeChoresCount: Int {
+        chores.filter { $0.isFinished == true }.count
+    }
+
+    // MARK: - Private properties
+
+    @ObservedObject private var userCollection: UserCollection
+    private var cancellable: AnyCancellable?
+
+    // MARK: - Life cycle
+
+    init(userCollection: UserCollection = .shared) {
+        self.userCollection = userCollection
+
+        cancellable = self.userCollection.$chores
+            .receive(on: DispatchQueue.main)
+            .sink { chores in
+                self.chores = chores
+        }
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreFormView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreFormView.swift
@@ -1,0 +1,102 @@
+//
+//  ChoreFormView.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 29.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+import SwiftUIKit
+import Backend
+
+struct ChoreFormView: View {
+
+    // MARK: - Properties
+
+    @Environment(\.presentationMode) private var presentationMode
+    @ObservedObject private var viewModel: ChoreFormViewModel
+    @State private var titleErrorBorderColor: Color = .clear
+
+    // MARK: - Life cycle
+
+    init(viewModel: ChoreFormViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                HStack {
+                    Text("Title")
+                    Spacer()
+                    TextField("Chore title",
+                              text: $viewModel.chore.title,
+                              onEditingChanged: { _ in self.titleErrorBorderColor = .clear })
+                        .foregroundColor(.acText)
+                }
+                .border(titleErrorBorderColor)
+
+                HStack {
+                    Text("Description")
+                    Spacer()
+                    TextField("Short description about the chore",
+                              text: $viewModel.chore.description)
+                        .foregroundColor(.acText)
+                }
+            }
+            .navigationBarTitle("Add Chore")
+            .navigationBarItems(leading: dismissButton, trailing: saveButton)
+        }
+        .navigationViewStyle(StackNavigationViewStyle())
+    }
+
+    // MARK: - Private
+
+    private var dismissButton: some View {
+        Button(action: {
+            self.presentationMode.wrappedValue.dismiss()
+        }) {
+            Image(systemName: "xmark.circle.fill")
+                .style(appStyle: .barButton)
+                .foregroundColor(.red)
+        }
+        .buttonStyle(BorderedBarButtonStyle())
+        .accentColor(Color.red.opacity(0.2))
+    }
+
+    private var saveButton: some View {
+        Button(action: {
+            guard !self.viewModel.chore.title.isEmpty else {
+                self.titleErrorBorderColor = .red
+                return
+            }
+
+            self.viewModel.save()
+            self.presentationMode.wrappedValue.dismiss()
+        }) {
+            Image(systemName: "checkmark.seal.fill")
+                .style(appStyle: .barButton)
+                .foregroundColor(.acTabBarBackground)
+        }
+        .buttonStyle(BorderedBarButtonStyle())
+        .accentColor(Color.acTabBarBackground.opacity(0.2))
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct ChoreFormView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ChoreFormView(viewModel: ChoreFormViewModel(chore: nil))
+
+            ChoreFormView(viewModel: ChoreFormViewModel(chore: Chore(title: "Collect Apple",
+                                                                     description: "To sell in another island",
+                                                                     isFinished: false)))
+                .preferredColorScheme(.dark)
+        }
+    }
+}
+#endif

--- a/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListRowView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListRowView.swift
@@ -1,0 +1,64 @@
+//
+//  ChoreListRowView.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 29.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+import Backend
+
+struct ChoreListRowView: View {
+
+    // MARK: - Properties
+
+    private let chore: Chore
+    private let id = UUID()
+
+    // MARK: - Life cycle
+
+    init(chore: Chore) {
+        self.chore = chore
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(chore.title)
+                    .style(appStyle: .rowTitle)
+
+                if !chore.description.isEmpty {
+                    Text(chore.description)
+                        .style(appStyle: .rowDescription)
+                }
+            }
+
+            Spacer()
+
+            if chore.isFinished {
+                Image(systemName: "circle.fill")
+                    .foregroundColor(.acHeaderBackground)
+            } else {
+                Image(systemName: "circle")
+                    .foregroundColor(.acHeaderBackground)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct ChoreListRowView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ChoreListRowView(chore: Chore(title: "Find Rocks", isFinished: false))
+                .preferredColorScheme(.light)
+                .previewLayout(.sizeThatFits)
+
+            ChoreListRowView(chore: Chore(title: "Sell Hot Items", description: "To pay the last loan", isFinished: true))
+                .preferredColorScheme(.dark)
+                .previewLayout(.sizeThatFits)
+        }
+    }
+}
+#endif

--- a/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListView.swift
@@ -1,0 +1,82 @@
+//
+//  ChoreListView.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 29.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+import Backend
+
+struct ChoreListView: View {
+
+    // MARK: - Properties
+
+    @ObservedObject private var viewModel: ChoreListViewModel
+    @State private var sheet: Sheet.SheetType?
+
+    // MARK: - Life cycle
+
+    init(viewModel: ChoreListViewModel = ChoreListViewModel()) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        List {
+            Button(action: {
+                self.sheet = .choreForm(chore: nil)
+            }, label: {
+                Text("Add Chore")
+                    .foregroundColor(.acHeaderBackground)
+            })
+
+            self.makeDescriptionView()
+
+            ForEach(self.viewModel.chores, id: \.id) { chore in
+                ChoreListRowView(chore: chore).onTapGesture {
+                    self.viewModel.toggleChore(chore)
+                }
+            }.onDelete { indexes in
+                self.viewModel.deleteChore(at: indexes.first!)
+            }
+        }
+        .navigationBarTitle(Text("Chores"), displayMode: .automatic)
+        .navigationBarItems(trailing: self.makeNavigationBarItems() )
+        .sheet(item: $sheet, content: { Sheet(sheetType: $0) })
+    }
+
+    // MARK: - Private
+
+    private func makeDescriptionView() -> some View {
+        guard viewModel.shouldShowDescriptionView else {
+            return EmptyView().eraseToAnyView()
+        }
+
+        return MessageView(string: "Have a friend to visit? A gift to a villager? Track your chores and to-dos here.")
+            .eraseToAnyView()
+    }
+
+    private func makeNavigationBarItems() -> some View {
+        guard viewModel.shouldShowResetButton else {
+            return EmptyView().eraseToAnyView()
+        }
+
+        return Button("Reset") {
+            self.viewModel.resetChores()
+        }.eraseToAnyView()
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct ChoreListView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ChoreListView()
+        }
+        .environmentObject(UserCollection.shared)
+    }
+}
+#endif

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/Sheet.swift
@@ -19,6 +19,7 @@ struct Sheet: View {
         case subscription(source: SubscribeView.Source, subManager: SubscriptionManager)
         case settings(subManager: SubscriptionManager, collection: UserCollection)
         case designForm(editingDesign: Design?)
+        case choreForm(chore: Chore?)
 
         var id: String {
             switch self {
@@ -40,6 +41,8 @@ struct Sheet: View {
                 return "userListForm"
             case .designForm:
                 return "designForm"
+            case .choreForm:
+                return "choreForm"
             }
         }
     }
@@ -75,9 +78,12 @@ struct Sheet: View {
                 TodaySectionEditView(viewModel: viewModel)
             }
             .navigationViewStyle(StackNavigationViewStyle()))
+        case .choreForm(let chore):
+            let viewModel = ChoreFormViewModel(chore: chore)
+            return AnyView(ChoreFormView(viewModel: viewModel))
         }
     }
-    
+
     var body: some View {
         make()
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayChoresSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayChoresSection.swift
@@ -1,0 +1,80 @@
+//
+//  TodayChoresSection.swift
+//  ACHNBrowserUI
+//
+//  Created by Otavio Cordeiro on 29.05.20.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+import Backend
+import UI
+
+struct TodayChoresSection: View {
+
+    // MARK: - Properties
+
+    @ObservedObject private var viewModel: TodayChoresSectionViewModel
+
+    // MARK: - Life cycle
+
+    public init(viewModel: TodayChoresSectionViewModel = TodayChoresSectionViewModel()) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        Section(header: SectionHeaderView(text: "Chores", icon: "checkmark.seal.fill")) {
+            NavigationLink(destination: ChoreListView()) {
+                VStack(alignment: .leading) {
+                    self.makeHeaderView()
+
+                    HStack(spacing: 15) {
+                        self.makeProgressView()
+                        self.makeRatioLabel()
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 8)
+                }
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    func makeHeaderView() -> some View {
+        Text("Manage and keep track of your chores and to-dos.")
+            .style(appStyle: .rowDescription)
+            .lineLimit(2)
+            .frame(maxHeight: .infinity)
+            .padding(.top, 8)
+    }
+
+    private func makeProgressView() -> some View {
+        return ProgressView(progress: CGFloat(viewModel.completeChoresCount) / CGFloat(viewModel.totalChoresCount),
+                            trackColor: .acText,
+                            progressColor: .acHeaderBackground,
+                            height: 12)
+    }
+
+    private func makeRatioLabel() -> some View {
+        return Text("\(viewModel.completeChoresCount) / \(viewModel.totalChoresCount)")
+            .font(Font.system(size: 12,
+                              weight: Font.Weight.semibold,
+                              design: Font.Design.rounded).monospacedDigit())
+            .foregroundColor(.acText)
+    }
+}
+
+struct TodayCustomTasksSection_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            List {
+                TodayChoresSection()
+            }
+            .listStyle(GroupedListStyle())
+            .environment(\.horizontalSizeClass, .regular)
+        }
+        .previewLayout(.sizeThatFits)
+        .environmentObject(UserCollection.shared)
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionEditView.swift
@@ -83,6 +83,7 @@ extension TodaySection {
         case .mysteryIsland: return "Mystery Islands"
         case .music: return "Music player"
         case .tasks: return "Today's Tasks"
+        case .chores: return "Chores"
         case .nookazon: return "New on Nookazon"
         }
     }
@@ -99,6 +100,7 @@ extension TodaySection {
         case .mysteryIsland: return "sun.haze.fill"
         case .music: return "music.note"
         case .tasks: return "checkmark.seal.fill"
+        case .chores: return "checkmark.seal.fill"
         case .nookazon: return "cart.fill"
         }
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySectionView.swift
@@ -51,6 +51,8 @@ struct TodaySectionView: View {
             return AnyView(TodayMusicPlayerSection())
         case .tasks:
             return AnyView(TodayTasksSection())
+        case .chores:
+            return AnyView(TodayChoresSection())
         case .nookazon:
             return AnyView(TodayNookazonSection(sheet: $selectedSheet, viewModel: viewModel))
         }


### PR DESCRIPTION
This commit adds custom Chores and To-Dos to the Dashboard.

This feature complements the Daily Tasks Section. It adds a way for the user to track chores and other actions they have to do when playing. For instance:

- Send a card to a friend
- Build an specific gift to a villager
- Sell scorpions to Flick
- Etc...

Think of it as todo app inside the app :-)

![output](https://user-images.githubusercontent.com/139272/83343265-28e66b80-a2f8-11ea-98cb-f85b83f4cce1.gif)
