### PR TITLE
Add sort villagers by personality

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/extensions/Array.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/extensions/Array.swift
@@ -14,6 +14,12 @@ public extension Array {
             Array(self[$0 ..< Swift.min($0 + size, count)])
         }
     }
+
+    func sortedByLocalizedString(using keyPath: KeyPath<Element, String>, direction: ComparisonResult) -> [Element] {
+        return sorted {
+            $0[keyPath: keyPath].localizedCompare($1[keyPath: keyPath]) == direction
+        }
+    }
 }
 
 

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
@@ -72,7 +72,7 @@ class VillagersViewModel: ObservableObject {
     // MARK: - Sort
     
     enum Sort: String, CaseIterable {
-        case name, species
+        case name, species, personality
     }
         
     var sort: Sort? {
@@ -81,13 +81,16 @@ class VillagersViewModel: ObservableObject {
                 sortedVillagers = []
                 return
             }
+
+            let order: ComparisonResult = sort == oldValue ? .orderedDescending : .orderedAscending
+
             switch sort {
             case .name:
-                let order: ComparisonResult = sort == oldValue ? .orderedDescending : .orderedAscending
-                sortedVillagers = villagers.sorted{ $0.localizedName.localizedCompare($1.localizedName) == order }
+                sortedVillagers = villagers.sortedByLocalizedString(using: \Villager.localizedName, direction: order)
             case .species:
-                let order: ComparisonResult = sort == oldValue ? .orderedDescending : .orderedAscending
-                sortedVillagers = villagers.sorted{ $0.species.localizedCompare($1.species) == order }
+                sortedVillagers = villagers.sortedByLocalizedString(using: \Villager.species, direction: order)
+            case .personality:
+                sortedVillagers = villagers.sortedByLocalizedString(using: \Villager.personality, direction: order)
             }
         }
     }


### PR DESCRIPTION
Sorting villagers by personality makes it easier to find villagers that hands specific items.