### PR TITLE
Critterpedia sorting

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/Item.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/packages/Backend/Sources/Backend/models/Item.swift
@@ -42,6 +42,7 @@ public struct Item: Codable, Equatable, Identifiable, Hashable {
     
     public var id: String { name }
     public var internalID: Int?
+    public var critterId: Int?
     
     public var localizedName: String {
         if let id = internalID {

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
@@ -26,6 +26,21 @@ class ItemsViewModel: ObservableObject {
     
     enum Sort: String, CaseIterable {
         case name, buy, sell, set, similar, critterpedia
+
+        static func allCases(for category: Backend.Category) -> [Sort] {
+            allCases.filter { $0.canSort(category) }
+        }
+
+        private func canSort(_ category: Backend.Category) -> Bool {
+            switch self {
+            case .buy, .similar, .set:
+                return ![Backend.Category.bugs, .fish, .fossils].contains(category)
+            case .critterpedia:
+                return [Backend.Category.bugs, .fish].contains(category)
+            default:
+                return true
+            }
+        }
     }
         
     var sort: Sort? {

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
@@ -34,9 +34,9 @@ class ItemsViewModel: ObservableObject {
         private func canSort(_ category: Backend.Category) -> Bool {
             switch self {
             case .buy, .similar, .set:
-                return ![Backend.Category.bugs, .fish, .fossils].contains(category)
+                return ![.bugs, .fish, .fossils].contains(category)
             case .critterpedia:
-                return [Backend.Category.bugs, .fish].contains(category)
+                return [.bugs, .fish].contains(category)
             default:
                 return true
             }

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
@@ -25,7 +25,7 @@ class ItemsViewModel: ObservableObject {
     private static var META_KEYWORD_CACHE: [String: [Item]] = [:]
     
     enum Sort: String, CaseIterable {
-        case name, buy, sell, set, similar
+        case name, buy, sell, set, similar, critterpedia
     }
         
     var sort: Sort? {
@@ -47,6 +47,10 @@ class ItemsViewModel: ObservableObject {
             case .similar:
                 let compare: (String, String) -> Bool = sort == oldValue ? (<) : (>)
                 sortedItems = items.filter{ $0.tag != nil}.sorted{ compare($0.tag!, $1.tag!) }
+            case .critterpedia:
+                let compare: (Int, Int) -> Bool = sort == oldValue ? (>) : (<)
+                sortedItems = items.filter{ $0.critterId != nil}
+                                .sorted{ compare($0.critterId!, $1.critterId!) }
             }
         }
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/ItemsListView.swift
@@ -63,7 +63,7 @@ struct ItemsListView: View {
     
     private var sortSheet: ActionSheet {
         var buttons: [ActionSheet.Button] = []
-        for sort in ItemsViewModel.Sort.allCases {
+        for sort in ItemsViewModel.Sort.allCases(for: viewModel.category) {
             buttons.append(.default(Text(LocalizedStringKey(sort.rawValue.localizedCapitalized)),
                                     action: {
                                         self.viewModel.sort = sort


### PR DESCRIPTION
- Added an option to sort Bugs and Fish according to Critterpedia order.
Super useful when updating in-app list with in-game collected critter list for the first time.

- Hide sort options unsupported by current collection.
For example, since critters and fossils can’t be bought, a list sorted by “Buy” would just go blank otherwise.