### PR TITLE
Add Description to Villager Row View

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
@@ -11,27 +11,34 @@ import Combine
 import Backend
 
 class VillagersViewModel: ObservableObject {
-    private static var cachedVillagers: [Villager] = []
-    
+
+    // MARK: - Public properties
+
     @Published var villagers: [Villager] = []
     @Published var searchResults: [Villager] = []
     @Published var searchText = ""
     @Published var todayBirthdays: [Villager] = []
     @Published var sortedVillagers: [Villager] = []
 
+    // MARK: - Private properties
+
+    private static var cachedVillagers: [Villager] = []
     private var apiPublisher: AnyPublisher<[String: Villager], Never>?
     private var searchCancellable: AnyCancellable?
+
     private var apiCancellable: AnyCancellable? {
         willSet {
             apiCancellable?.cancel()
         }
     }
-    
+
     private var today: String {
         let formatter = DateFormatter()
         formatter.dateFormat = "d/M"
         return formatter.string(from: Date())
     }
+
+    // MARK: - Life cycle
     
     init() {
         searchCancellable = $searchText
@@ -62,7 +69,9 @@ class VillagersViewModel: ObservableObject {
                 self?.todayBirthdays = $0.filter( { $0.birthday == self?.today })
             })
     }
-    
+
+    // MARK: - Private
+
     private func villagers(with string: String) -> [Villager] {
         villagers.filter {
             $0.localizedName.lowercased().contains(string.lowercased()) == true

--- a/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagerRowView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagerRowView.swift
@@ -11,10 +11,28 @@ import Backend
 import UI
 
 struct VillagerRowView: View {
+
+    // MARK: - Type
+
+    enum Style {
+        case none
+        case species
+        case personality
+    }
+
+    // MARK: - Properties
+
     @EnvironmentObject private var collection: UserCollection
-    
-    let villager: Villager
-    
+    private let villager: Villager
+    private let style: Style
+
+    // MARK: - Life cycle
+
+    init(villager: Villager, style: Style = .none) {
+        self.villager = villager
+        self.style = style
+    }
+
     var body: some View {
         HStack {
             LikeButtonView(villager: villager)
@@ -22,8 +40,21 @@ struct VillagerRowView: View {
             ItemImage(path: ACNHApiService.BASE_URL.absoluteString +
                 ACNHApiService.Endpoint.villagerIcon(id: villager.id).path(),
                       size: 50)
-            Text(villager.localizedName)
-                .style(appStyle: .rowTitle)
+
+            VStack(alignment: .leading) {
+                Text(villager.localizedName)
+                    .style(appStyle: .rowTitle)
+
+                if style == .species {
+                    Text(villager.species)
+                        .font(.subheadline)
+                        .foregroundColor(.acSecondaryText)
+                } else if style == .personality {
+                    Text(villager.personality)
+                        .font(.subheadline)
+                        .foregroundColor(.acSecondaryText)
+                }
+            }
         }
     }
 }
@@ -31,7 +62,13 @@ struct VillagerRowView: View {
 struct VillagerRowView_Previews: PreviewProvider {
     static var previews: some View {
         List {
-            VillagerRowView(villager: static_villager)
+            VillagerRowView(villager: static_villager, style: .none)
+                .environmentObject(UserCollection.shared)
+
+            VillagerRowView(villager: static_villager, style: .species)
+                .environmentObject(UserCollection.shared)
+
+            VillagerRowView(villager: static_villager, style: .personality)
                 .environmentObject(UserCollection.shared)
         }
     }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagerRowView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagerRowView.swift
@@ -59,6 +59,9 @@ struct VillagerRowView: View {
     }
 }
 
+// MARK: - Preview
+
+#if DEBUG
 struct VillagerRowView_Previews: PreviewProvider {
     static var previews: some View {
         List {
@@ -73,3 +76,4 @@ struct VillagerRowView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/villagers/VillagersListView.swift
@@ -33,7 +33,7 @@ struct VillagersListView: View {
                 {
                     ForEach(currentVillagers) { villager in
                         NavigationLink(destination: VillagerDetailView(villager: villager)) {
-                            VillagerRowView(villager: villager)
+                            self.makeRowView(villager: villager)
                         }
                     }
                 }
@@ -55,6 +55,20 @@ struct VillagersListView: View {
                 }
             }
         }
+    }
+
+    // MARK: - Private
+
+    private func makeRowView(villager: Villager) -> some View {
+        let style: VillagerRowView.Style
+
+        switch viewModel.sort {
+        case .species: style = .species
+        case .personality: style = .personality
+        default: style = .none
+        }
+
+        return VillagerRowView(villager: villager, style: style)
     }
 }
 


### PR DESCRIPTION
When filtering villagers by species or personally, it's hard to tell where the next species and personalities start and end.

This feature helps people sorting villagers by species/personalities when they want to invite villagers to move to the island or visit the camp (using amiibos).

The image below shows the villagers list a) without filter, b) filtered by name, c) filtered by species, and 4) by personality.

![villagers_filter](https://user-images.githubusercontent.com/139272/83451554-79c0a600-a457-11ea-842d-7a5a8168cb6c.png)
