### PR TITLE
Add Italian translations for custom tasks

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
@@ -788,9 +788,9 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "A very rare island with flowers, scorpions and a rectangular pond. If you climb up onto the cliff and climb down from the back, you can vault over to a tiny island in the middle and get 8 gold nuggets from a single rock." = "Un’isola molto rara con fiori, scorpioni e uno stagno rettangolare. Se ti arrampichi sul rilievo e poi scendi dietro dall’altra parte puoi saltare con l’asta su di una piccola isola che sta nel mezzo. Lì puoi prendere 8 minerali d’oro da una roccia.";
 
 // Added 2020-05-20		
-"Same color" = "Stesso colore";		
-// New settings		
-"Using iCloud sync" = "Utilizza sincronizzazione iCloud";		
+"Same color" = "Stesso colore";
+// New settings
+"Using iCloud sync" = "Utilizza sincronizzazione iCloud";
 "Synchronized with iCloud" = "Sincronizzato con iCloud";
 
 "Possible visitors" = "Visitatori possibili";
@@ -976,7 +976,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Elegant" = "Élegante";
 "Dining" = "Sala da pranzo";
 "Wood Tile Walls" = "Muri Piastrelle di Legno";
-"Tile Floors" = Pavimenti a Piastrelle";
+"Tile Floors" = "Pavimenti a Piastrelle";
 "School" = "Scuola";
 "Cardboard" = "Cartone";
 "Tin Walls" = "Muri di Latta";

--- a/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
@@ -1,562 +1,4 @@
-/*
- Localizable.strings
- ACHNBrowserUI
- 
- Created by Jan on 09.05.20.
- Copyright © 2020 Thomas Ricouard. All rights reserved.
- */
-
-"Loading..." = "Cargando...";
-"Tap here to preview a notification" = "Pulsa aquí para previsualizar una notificación";
-"Upgrade to +" = "Mejorar a +";
-"You're subscribed to AC Helper+" = "Te has suscrito a AC Helper+";
-
-"Close" = "Cerrar";
-"Dismiss" = "Cancelar";
-"Save" = "Guardar";
-
-"EEEE, dd MMMM" = "EEEE, dd MMMM";
-"dM" = "dM";
-"dd" = "dd";
-"MMM" = "MMM";
-"MMM dd" = "MMM dd";
-"dd MMMM" = "dd MMMM";
-
-"Dashboard" = "Pantalla Principal";
-"Catalog" = "Catálogo";
-"Turnips" = "Nabos";
-"Villagers" = "Aldeanos";
-"Collection" = "Colección";
-
-"Change Section Order" = "Cambiar el orden de las secciones";
-
-"Drag & Drop to Rearrange" = "Arrastra y suelta para reorganizar";
-"Hidden" = "Oculto";
-"Today Sections" = "Secciones principales";
-"Done" = "Hecho";
-" to re-order sections." = " para reorganizar las secciones.";
-"Check or un-check" = "verifica o no verifica";
-" rows to hide sections from the dashboard." = " para esconder las secciones principales";
-
-"Birthdays" = "Cumpleaños";
-"Today's Birthdays" = "Cumpleaños de hoy";
-"Today's Birthday" = "Cumpleaños de hoy";
-
-"Collection Progress" = "Progreso de la colección";
-"Share" = "Compartir";
-
-"Currently Available" = "Disponible ahora";
-"%lld/%lld Bugs" = "%lld/%lld Insectos";
-"%lld/%lld Fish" = "%lld/%lld Peces";
-"%lld NEW" = "%lld NUEVO";
-
-"Events" = "Eventos";
-"Currently" = "En este momento";
-"No Events Today" = "No hay eventos hoy";
-"Upcoming" = "Próximamente";
-
-"Today's Tasks" = "Tareas de hoy";
-"This feature requires " = "Esta función requiere ";
-"Learn more >" = "Saber más >";
-
-"Today is sunday, don't forget to buy more turnips and fill your buy price." = "¡Hoy es domingo! No olvides comprar más nabos y poner tu precio de compra.";
-"Today's average price should be around " = "El precio medio de hoy debería ser sobre";
-" in the morning, and " = " por la mañana, y ";
-" this afternoon." = " por la tarde.";
-
-"New on Nookazon" = "Nuevo en Nookazon";
-"Nookazon is loading..." = "Nookazon está cargando...";
-
-"What's New" = "Novedades";
-"See what's new in update %@" = "Mira qué hay de nuevo en esta actualización %@";
-
-"You're subscribed to AC Helper+. Thank you so much for you support!" = "Te has suscrito a AC Helper*. ¡Muchas gracias por tu apoyo!";
-"If you enjoy the application, consider subscribing to AC Helper+, to get access to some awesome features and support us!" = "¡Si disfrutas de la aplicación, considera suscribirte a AC Helper+, para obtener acceso a funciones asombrosas y apoyarnos!";
-
-"AC Helper+" = "AC Helper+";
-"ACHelperPlusDescription" = "Suscribirte a AC Helper+ es una excelente forma de mostrar tu apoyo a nuestro proyecto gratuito de código abierto.♥️
-
-¡También tendrás acceso a otras funciones, como predicciones de los precios de los nabos y la capacidad de crear más de una lista de objetos!  📈";
-
-"ACHelperPlusDetails" = "Sobre la función de notificación:
-
-Diariamente a las 8 am. y a las 12 pm., recibirás una notificación con el precio promedio de compra en tu tienda.
-
-¡Cuantos más precios diarios agregues después del lunes por la mañana en la aplicación, más precisas serán las próximas predicciones!
-
-Sobre la funcionalidad de la lista de objetos:
-
-En la aplicación gratuita, solo puedes crear una sola lista de elementos en la pestaña de su colección.
-
-Una vez que te hayas suscrito a AC Helper +, puedes crear tantas listas como desees.";
-
-"ACHelperPlusPriceAndAboDetail %@ %@" = "Las compras de %@ por mes o %@ por año serán aplicadas a tu cuenta de iTunes.
-
-Las suscripciones se renovarán automáticamente si no son canceladas 24h antes de finalizar la suscripción.
-
-Puedes cancelar en cualquier momento desde los ajustes de iTunes. Cualquier periodo de prueba gratuita restante si se compra una suscripción será perdido";
-"Subscribe for %@ / Month" = "Suscríbete por %@ / Mes";
-"%@ Monthly" = "%@ / Mes";
-"%@ Yearly" = "%@ / Año";
-"Buy lifetime AC Helper+ for %@" = "Comprar AC Helper+ de por vida por %@";
-"Thank you for your support!" = "¡Gracias por tu apoyo!";
-"Thanks!" = "¡Gracias!";
-
-"About" = "Información";
-"The app" = "La app";
-"Souce code / report an issue" = "Código fuente / señalar un problema";
-"Contact / follow us on Twitter" = "Contacto / síguenos en Twitter";
-"Rate the app on the App Store" = "Valorar la App en la App Store";
-"Privacy Policy" = "Política de Privacidad";
-"Term of Use" = "Términos de Uso";
-"App version" = "Version de la app";
-"Game patch data" = "Versión del parche del juego";
-"Acknowledgements" = "Reconocimientos";
-"Our amazing contributors" = "Nuestros increíbles colaboradores";
-"The NookPlaza API by Azarro" = "La API de NookPlaza de Azarro";
-"Turnip.exchange" = "Turnip.exchange";
-"Nookazon for the marketplace" = "Nookazon para el mercado";
-"Shihab / JPEGuin for the icon" = "Shihab / JPEGuin por el icono";
-"Christian & Ninji for the turnip predictions algorithm" = "Christian & Ninji por el algoritmo de predicción de los nabos";
-"Error" = "Error";
-
-"Active Critters" = "Bichos atrapables";
-"Fishes" = "Peces";
-"Bugs" = "Insectos";
-"You caught them all!" = "¡Los has atrapado todos!";
-"New this month" = "Nuevo este mes";
-"To catch" = "Por atrapar";
-"Leaving this month" = "Abandonan este mes";
-"Caught" = "Atrapados";
-
-"Preferences" = "Preferencias";
-"Island name" = "Nombre de la isla";
-"Your island name" = "El nombre de tu isla";
-"Hemisphere" = "Hemisferio";
-"North" = "Norte";
-"South" = "Sur";
-"Starting fruit" = "Fruta inicial";
-"Apple" = "Manzana";
-"Cherry" = "Cereza";
-"Orange" = "Naranja";
-"Peach" = "Melocotón";
-"Pear" = "Pera";
-"Coconut" = "Coco";
-"Nook shop" = "Tienda Nook";
-"Tent" = "Tienda de campaña";
-"Nook's Cranny" = "MiniNook";
-"Nook's Cranny upgraded" = "MiniNook mejorado";
-"Able sisters" = "Hermanas Manitas";
-"Visiting" = "Visitando";
-"Shop" = "Tienda física";
-"Residents service" = "Oficina de gestión vecinal";
-"Building" = "Edificio";
-"App Settings" = "Ajustes de la App";
-"App Icon" = "Icono de la App";
-"Restore purchase" = "Restaurar compra";
-
-"Edit your list" = "Edita tú lista";
-"Name of your list" = "Nombre de tu lista";
-"List name" = "Nombre de la lista";
-"Can be nothing" = "Puede ser nada";
-"Icon" = "Icono";
-
-"Add %lld items" = "Añadie %lld objetos";
-"Edit" = "Editar";
-"Search items" = "Buscar objetos";
-"Items added to your list from the search will be displayed there." = "Los objetos añadidos a tu lista aparecerán aquí";
-"No results for %@" = "No hay resultados para %@";
-
-"In order to create more than one list, you need to subscribe to AC Helper+" = "Para crear más de una lista, necesitas suscribirte a AC Helper+";
-"Learn more..." = "Saber más...";
-
-"Create a new list" = "Crear una nueva lista";
-"Please select or go stars some items!" = "¡Selecciona o marca algunos objetos!";
-"When you stars some \%@, they'll be displayed here." = "Cuando marques algunos \%@, aparecerán aquí.";
-"Items" = "Objetos";
-"Critters" = "Bichos";
-"Lists" = "Listas";
-"More" = "Más";
-
-"Clear Selection" = "Limpiar la selección";
-"Sort items" = "Ordenar objetos";
-"Current Sort: %@" = "Orden por: %@";
-"name" = "nombre";
-"buy" = "precio de compra";
-"sell" = "precio de venta";
-"from" = "obtención";
-"set" = "set";
-"similar" = "similar";
-"Name" = "Nombre";
-"Buy" = "Precio de compra";
-"Sell" = "Precio de venta";
-"From" = "Obtención";
-"Set" = "Set";
-"Similar" = "Similar";
-
-"unknown source" = "Origen desconocido";
-
-"Rarity:" = "Rareza:";
-"Shadow size:" = "Tamaño de sombra:";
-"X-Small" = "Muy pequeña";
-"Small" = "Pequeña";
-"Medium" = "Mediana";
-"Large" = "Grande";
-"X-Large" = "Muy grande";
-"Customizable: %@" = "Personalizable: %@";
-"Yes" = "Sí";
-"No" = "No";
-"Common" = "Común";
-"Same color" = "Del mismo color";
-
-"Preview" = "Previsualizar";
-
-"Seasonality" = "De temporada";
-
-"Set items" = "Objetos del set";
-"Simillar items" = "Objetos similares";
-"Thematics" = "Temáticas";
-"Variants" = "Variantes";
-"Materials" = "Materiales";
-"Nookazon listings" = "Nookazon";
-"Loading Listings..." = "Cargando...";
-"No listings found on Nookazon" = "No se ha encontrado en Nookazon";
-"Your items lists" = "Tu lista de objetos";
-"Keywords" = "Palabras clave";
-
-"Minmax" = "Min-Max";
-"Profits" = "Beneficio";
-"Average daily buy prices" = "Precio diario de compra";
-"Daily min-max prices" = "Precio min-max diario";
-"Average profits" = "Precio medio";
-"Chart" = "Gráfico";
-"Mon" = "Lun";
-"Tue" = "Mar";
-"Wed" = "Mie";
-"Thu" = "Jue";
-"Fri" = "Vie";
-"Sat" = "Sab";
-"Your prices" = "Tus precios";
-"Edit your in game prices" = "Editar tus precios del juego";
-"Add your in game prices" = "Añadir tus precios de juego";
-"Turnips prediction" = "Predicción de nabos";
-"To help us support the application and get turnip predictions notification, you can try out AC Helper+" = "Para apoyar la aplicación y conseguir la notificación de predicción de nabos, puedes probar AC Helper+";
-"To help us support the application and get background playing of all the musics, you can try out AC Helper+" = "Para apoyar la aplicación y conseguir la música de fondo de todas las canciones, puedes probar AC Helper++";
-"%lld upcomingDailyNotifications" = "Has recibido %lld notificaciones.";
-"Profits estimates are computed using the average of the current period" = "Los beneficios estimados se basan en el precio medio del período actual";
-"Day" = "Día";
-"AM" = "AM";
-"PM" = "PM";
-"Please add the amount of turnips you bought and for how much" = "Por favor, añade la cantidad de nabos que has comprado y por cuánto";
-"Add your in game turnip prices to see the predictions chart" = "Añade tu precio de compra de nabos en el juego para ver el gráfico";
-"Add your in game turnip prices to see predictions" = "Añade tu precio de compra de nabos en el juego para ver predicciones";
-"Exchange" = "Cambio";
-
-"Monday" = "Lunes";
-"Tuesday" = "Martes";
-"Wednesday" = "Miércoles";
-"Thursday" = "Jueves";
-"Friday" = "Viernes";
-"Saturday" = "Sábado";
-"Add your turnip prices" = "Ajustar Los precios de los nabos";
-"Configuration" = "Configuración";
-"Clear all fields" = "Limpiar todo";
-"Receive prices predictions notification" = "Recibir las notificaciones de predicciones";
-"You can get daily notifications for your average turnip price by subscribing to AC Helper+" = "Puedes obtener notificaciones diarias de tu precio medio de nabos suscribiéndote a AC Helper+";
-"Preview a notification" = "Ver un ejemplo de notificación";
-"Your in game prices" = "Tus precios de juego";
-"Buy price" = "Precio de compra";
-"Amount bought" = "Cantidad comprada";
-"The more in game buy prices you'll add the better the predictions will be. Your buy price only won't give your correct averages. Add prices from the game as you get them daily." = "Cuantos mas precios de compra añadas mejor mes serán las predicciones. Solo tu precio de compra no te dará predicciones correctas. Añade precios del juego diariamente";
-"View on TurnipProphet" = "Ver en TurnipProphet";
-"View Turnip.Exchange islands" = "Ver las Islas de Turnip.Exchange";
-
-"Average" = "Medio";
-"Minimum" = "Mínimo";
-"MinMax" = "MinMax";
-
-"Join Island" = "Unirte a la isla";
-"Island" = "Isla";
-"Description" = "Descripción";
-"Visitors" = "Visitantes";
-"Loading Visitors...." = "Cargando visitantes....";
-
-"Search a villager" = "Buscar un vecino";
-"Personality" = "Personalidad";
-"Birthday" = "Cumpleaños";
-"Species" = "Especie";
-"Gender" = "Género";
-"Catch phrase" = "Frase típica";
-"Unknown" = "Desconocido";
-"Villager items" = "Objetos de vecinos";
-"Sort villagers" = "Ordenar vecinos";
-
-"Unkown" = "Desconocido";
-"Lazy" = "Perezoso";
-"Jock" = "Atlético";
-"Cranky" = "Gruñón";
-"Smug" = "Snob";
-"Normal" = "Normal";
-"Peppy" = "Alegre";
-"Snooty" = "Presumida";
-"Uchi" = "Dulce";
-"Male" = "Masculino";
-"Female" = "Femenino";
-"Alligator" = "Cocodrilo";
-"Anteater" = "Oso hormiguero";
-"Bear" = "Oso";
-"Bird" = "Pájaro";
-"Bull" = "Toro";
-"Cat" = "Gato";
-"Chicken" = "Pollo";
-"Cow" = "Vaca";
-"Cub" = "Lobo";
-"Deer" = "Ciervo";
-"Dog" = "Perro";
-"Duck" = "Pato";
-"Eagle" = "Águila";
-"Elephant" = "Elefante";
-"Frog" = "Rana";
-"Goat" = "Cabra";
-"Gorilla" = "Gorila";
-"Hamster" = "Hamster";
-"Hippo" = "Hipopótamo";
-"Horse" = "Casallo";
-"Kangaroo" = "Canguro";
-"Koala" = "Koala";
-"Lion" = "León";
-"Monkey" = "Mono";
-"Mouse" = "Ratón";
-"Octopus" = "Pulpo";
-"Ostrich" = "Avestruz";
-"Penguin" = "Pingüino";
-"Pig" = "Cerdo";
-"Rabbit" = "Coneji";
-"Rhino" = "Rinoceronte";
-"Sheep" = "Oveja";
-"Squirrel" = "Ardilla";
-"Tiger" = "Tigre";
-"Wolf" = "Lobo";
-"Like" = "Le gusta";
-"Gifts ideas" = "Ideas de regalo";
-
-"Make an Offer" = "Hacer una oferta";
-"Need Materials" = "Se necesitan materiales";
-
-"Turnip prices" = "Precio de nabos";
-"this morning" = "esta mañana";
-"this afternoon" = "esta tarde";
-"Your prices predictions for %@ should be around %lld bells. With a minimum of %lld and a maximum of %lld." = "Las predicciones para %@ deberían ser de %lld bayas. Con un mínimo de %lld y un máximo de %lld.";
-"Turnip prices (test)" = "recio de nabos (test)";
-"Your prices predictions for this morning should be around 100 bells. With a minimum of 50 and a maximum of 650." = "Las predicciones para esta mañana deberían ser de 100 bayas. Con un mínimo de 50 y un máximo de 650.";
-"Friendly reminder" = "Recordatorio amistoso";
-"It's time to buy turnips and add the buy price in the app." = "Es hora de comprar nabos y añadir el precio en la app.";
-"It's the start of the week, don't forget to add your store buy prices in the app as you play the game. You'll get more accurate predictions." = "Empieza la semana, no olvides añadir los precios de tu tienda en la app cuando juegues. Obtendrás unas predicciones más seguras. ";
-
-"housewares" = "Artículos del hogar";
-"miscellaneous" = "Varios";
-"wall-mounted" = "De pared";
-"wallpapers" = "Paredes";
-"floors" = "Suelos";
-"rugs" = "Alfombras";
-"photos" = "Fotos";
-"posters" = "Posters";
-"fencing" = "Vallas";
-"tools" = "Herramientas";
-"tops" = "Partes de arriba";
-"bottoms" = "Pantalones";
-"dresses" = "Vestidos";
-"headwear" = "Gorros";
-"accessories" = "Accesorios";
-"socks" = "Calcetines";
-"shoes" = "Zapatos";
-"bags" = "Bolsas";
-"umbrellas" = "Paraguas";
-"music" = "Música";
-"recipes" = "Recetas";
-"construction" = "Construcción";
-"nookmiles" = "Millas Nook";
-"other" = "Otros";
-"art" = "Arte";
-"bugs" = "Insectos";
-"fish" = "Peces";
-"fossils" = "Fósiles";
-
-"Nature" = "Natural";
-"Wardrobe" = "Armario";
-"No results for %@" = "Sin resultados para %@";
-
-"Search..." = "Buscar…";
-
-"See more" = "Ver más";
-"See less" = "Ver menos";
-
-"My data" = "Mis datos";
-"Collection size" = "Tamaño de mi colección";
-"Export my collection" = "Exportar mi colección";
-"Import a collection" = "Importar una colección";
-"Imported with success" = "Importado con éxito";
-"Reset my collection" = "Eliminar my colección";
-"Your AC Helper collection file was imported with success." = "Tu colección de AC Helper ha sido importada con éxito";
-"Are you sure?" = "¿Estás seguro?";
-"This will delete all your collected critters, items, villagers and items lists" = "Eso borrará todas tus colecciones de bichos, vecinos, objetos y listas.";
-
-"Mystery Islands" = "Islas misteriosas";
-"Trees: %@" = "Árboles: %@";
-"Trees" = "Árboles";
-"Flowers" = "Flores";
-"Flowers: %@" = "Flores: %@";
-"Fish" = "Peces";
-"Insects" = "Insectos";
-"Rocks Type" = "Tipo de rocas";
-"Rocks" = "Rocas";
-"Take your chance and go visit some mystery island!" = "¡Toma tu oportunidad y visita alguna Isla misteriosa!";
-"Native" = "Nativo";
-"Normal" = "Normal";
-"Uncommon" = "Poco común";
-"Gold" = "Pepitas de oro";
-"Trash" = "Basura";
-"Bamboos" = "Bambús";
-"Hardwood" = "Caducifolio";
-"Exotic fruits" = "Frutas exóticas";
-"Normal Island 1" = "Isla Normal 1";
-"Normal Island 2" = "Isla Normal 2";
-"Spiral Island" = "Isla Espiral";
-"Fidget Spinner Island" = "Isla del Fidget Spinner";
-"Mountain Island" = "Isla de la Montaña";
-"Bells Island" = "Isla de las Bayas";
-"Bamboo Island" = "Isla de Bambú";
-"Fruit Island" = "Isla de la Fruta";
-"Flower Island" = "Isla de las Flores";
-"Bell Island 2" = "Isla de las Bayas 2";
-"Tarantula Island" = "Isla de las Tarántulas";
-"Tree Island" = "Isla de los Árboles";
-"Big fish Island" = "Isla de Peces Grandes";
-"Tree Island 2" = "Isla de los Árboles 2";
-"Curvy River Island" = "Isla del Río Curvo";
-"Big Fish Island 2" = "Isla de los Peces Grandes 2";
-"Trash Island" = "Isla de la Basura";
-"Fins Island" = "Isla de Aletas";
-"Falls Island" = "Isla de las Cascadas";
-"Gold Island" = "Isla de las Pepitas de Oro";
-" - max %lld visit" = " - máx %lld visita";
-
-"River" = "Río";
-"Sea" = "Océano";
-"Ponds" = "Estanques";
-"Pond" = "Estanque";
-"Pier" = "Muelle";
-"Raining" = "Lluvia";
-"Clifftop" = "Sobre acantilado";
-"Mouth" = "Desembocadura";
-"Flying near flowers" = "Volando cerca de flores";
-"On the ground" = "En el suelo";
-"Flying" = "Volando por el aire";
-"Shaking trees (hardwood or cedar only)" = "Agitando árboles (Solo caducifolios o cedros)";
-"On trees (any kind)" = "En árboles (de todo tipo)";
-"Disguised on shoreline" = "Distinguido en la costa";
-"Pushing snowballs" = "Poniendo bolas de nieve";
-"On flowers" = "En las flores";
-"On tree stumps" = "En tocones de árbol";
-"On palm trees" = "Dn las palmeras";
-"On hardwoodcedar trees" = "En árboles caduciformes";
-"From hitting rocks" = "Golpeando rocas";
-"On riverponds" = "En estanques";
-"On rocks" = "En las rocas";
-"On rotten turnips" = "En nabos podridos";
-"Shaking trees" = "Agitando árboles";
-"On white flowers" = "En flores blancas";
-"Flying near trash (boots, tires, cans)" = "Volando cerca de basura (botas, neumáticos, latas...)";
-"Flying near bluepurpleblack flowers" = "Volando cerca de flores azules/moradas/negras";
-"Deguised under trees" = "Camuflado bajo árboles";
-"On villager" = "En un vecino";
-"Underground (dig where noise is loudest)" = "Bajo tierra (cavar donde el sonido es más fuerte)";
-"Jolly Redd's Treasure Trawler" = "Navío Ambulante de Ladino";
-"Mom" = "Mamá";
-"Dad" = "Papá";
-"Fishing Tourney" = "Torneo de pesca";
-"Picking flowers" = "Recoger flores";
-"Hitting a rock" = "Golpear una roca";
-"Beach" = "Playa";
-
-"A fairly normal island which you can get on your first tour, with one cliff, native fruit, coconuts, a river and a pond." = "Una isla normal donde puedes ir en tu primer tour, con un acantilado, fruta nativa, cocos, un río y un estanque";
-"Practically the same as Normal Island 1, but without the pond, and with a slightly bigger cliff." = "Prácticamente lo mismo que la Isla Normal 1, pero sin el estanque y con un acantilado un poco más grande.";
-"Somewhat more interesting in layout but it has nothing special about the resources you can get." = "Un tipo con una forma diferente más interesante pero con ningún recurso especial para obtener.";
-"The last of the four starter islands. No river, just a pond and the sea." = "La última de las cuatro islas principales. Sin río, solo con un estanque y el mar.";
-"Multiple levels, no river. The base level has regular trees, the middle level has your native fruit, and the top level has five rocks with materials." = "Distintas alturas, sin río. El nivel base tiene árboles normales, el nivel medio tu fruta nativa, y el nivel más alto 5 rocas con materiales";
-"Breaking the rock at the far north will let you vault over into the island with five money rocks on it." = "Romper la roca del norte te permitirá saltar a la isla con 5 rocas de dinero en ella";
-"Every tree on this island is bamboo and you can get to it at any time of year. The most common island you can get out of the 20, statistically." = "Cada árbol de esta isla es bambú y puedes ir durante todo el año. La isla más común de conseguir de las 20, estadísticamente";
-"There are 19 fruit trees on this island and all will be your 'sister fruit'. This will be different from your native fruit - but every time you come here, it will be the same one." = "Hay 19 árboles frutales en esta isla y todos serán de tu 'fruta hermana'. Esta es distinta de tu fruta nativa - pero cada vez que vengas aquí, será la misma.";
-"This island has a pond surrounded by rare flowers and the only insects that will spawn are those that hang around flowers." = "Esta isla tiene un estanque rodeado de flores raras y los únicos insectos que aparecerán son aquellos que vuelan alrededor de flores";
-"There are four small triangular cliffs, one in each corner, and the ground level is full of flowers and money rocks." = "Hay 4 pequeños acantilados triangulares, uno en cada esquina, y el nivel del suelo está lleno de flores y rocas de dinero";
-"Yes, the infamous one. The only insects that spawn here are tarantulas (as long as it is night time in a Tarantula month), and the rocks have crafting materials if you can get to them. The river is thin enough that you can jump over it without a vaulting pole." = "Si, la infame. Los únicos insectos que aparecen aquí son tarántulas (mientras sea de noche y en un mes que haya tarántulas), y las rocas tienen materiales si puedes llegar a ellas. El río es lo suficientemente fino como para saltar sin pértiga.";
-"This island has no river or pond and has tons of hardwood and coconut trees, and the only insects that spawn are those that are associated with trees." = "Esta isla no tiene río ni estanque y tiene un montón de árboles caducifolios y palmeras de cocos, los únicos insectos que aparecen son aquellos asociados con los árboles.";
-"Big Fish Island. This island has rare hybrid flowers and the only fish available are larger ones, including some of the more rare ones." = "La isla de los peces grandes, tiene flores híbridas bastante raras y los únicos peces disponibles son los más grandes, incluyendo los más raros.";
-"This island is exactly the same as Bamboo Island but the trees are all just regular hardwood trees." = "Esta isla es exactamente igual que la Isla de Bambú, pero los árboles son únicamente caducifolios.";
-"There is one square cliff at the north east, a few flowers and rocks and a small amount of fruit trees. Only insects associated with water spawn here." = "Hay un acantilado cuadrado en el noreste, unas cuantas flores y rocas y un puñado de árboles frutales. Solo los insectos asociados con agua aparecen aquí.";
-"This rare island only spawns big fish. Otherwise it is quite normal, with less flowers and a lower chance of appearing than the other big fish island." = "Esta rara isla solo tiene peces grandes. Por lo demás es bastante normal, con menos flores y menos probabilidad de aparecer que la otra isla de peces grandes";
-"Everything you can fish here is trash. Only water-related insects spawn." = "Todo lo que pesques aquí será basura. Solo aparecen insectos relacionados con el agua.";
-"A rectangular pond with rectangular cliffs inside, the tallest one being too tall to climb up to. The only fish that spawn here are the largest finned fish." = "Un estanque rectangular con acantilados cuadrados dentro, el más alto es demasiado alto como para escalarlo. Los únicos peces que  aparecen aquí son los largos y finos.";
-"Lots of cliffs, waterfalls and river forks. Normal resource spawns." = "Muchos acantilados, cascadas y cruces de ríos. Aparecen recursos normales.";
-"A very rare island with flowers, scorpions and a rectangular pond. If you climb up onto the cliff and climb down from the back, you can vault over to a tiny island in the middle and get 8 gold nuggets from a single rock." = "Una isla muy rara con flores, escorpiones y un estanque rectangular. Si escalas el acantilado y bajas por la parte trasera, podrás llegar a una pequeña isla en el centro y obtener 8 pepitas de oro de una sola roca.";
-
-"Using iCloud sync" = "Usando sincronización con iCloud";
-"Synchronized with iCloud" = "Sincronizado con iCloud";
-
-"Possible visitors" = "Posibles visitantes";
-"On" = "en";
-" your island" = " tu isla";
-"All day" = "Todo el día";
-"From 6pm to 5am" = "De 18H a 5H";
-"From 8pm to 5am" = "De 20H a 5H";
-"From 5am to 12pm" = "De 5H a 12H";
-
-"K.K Slider" = "Totakeke";
-"Daisy Mae" = "Juliana";
-"C.J" = "CJ";
-"Flick" = "Kamilo";
-"Kicks" = "Betunio";
-"Saharah" = "Alcatifa";
-"Label" = "Trini";
-"Leif" = "Gandulio";
-"Redd" = "Ladino";
-"Wisp" = "Buh";
-"Celeste" = "Estela";
-
-"Museum Day" = "Día Internacional de los Museos";
-"Wedding Season" = "Temporada de bodas";
-"Bug-Off contest" = "Caza de Bichos";
-"Meteor shower" =  "Lluvia de meteoros";
-
-"Music player" = "Reproductor de música";
-"Tracks" = "Canciones";
-
-"Vacation" = "Vacaciones";
-"Stripe Walls" = "Pared de rayas";
-"Office" = "Oficina";
-"Tile Walls" = "Pared de azulejos";
-"Tea Room Walls" = "Paredes salón de té";
-"Zen" = "Zen";
-"Deco Wood" = "Decoración de madera";
-"Rubber" = "Caucho";
-"Picture" = "Foto";
-"Cloth Floors" = "Suelos de tela";
-"Audio" = "Música";
-"Fruits" = "Frutas";
-"Antique" = "Antigüedades";
-"Honeycomb" = "Panal";
-"Japanese Style" = "Estilo Japonés";
-"Simple Walls" = "Paredes Simples";
-"Golden" = "Dorado";
-"Simple" = "Simple";
-"Country" = "Campo";
-"Sports Floor" = "Suelo deportivo";
-"Bamboo" = "Bambú";
-"Art Deco Walls" = "Paredes decorativas del museo";
-"Outdoors" = "Exterior";
-"Rose Rug" = "Alfombra Rosa";
-"Fish" = "Pez";
-
+"Loading..." = "Caricamento...";
 "Tap here to preview a notification" = "Tocca per un anteprima della notifica";
 "Upgrade to +" = "Aggiorna a +";
 "You're subscribed to AC Helper+" = "Ti sei abbonato a AC Helper+";
@@ -654,11 +96,12 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "%@ Yearly" = "%@ all'anno";
 
 // AboutView
-"About" = "Informazoni su";
+"About" = "Informazioni su";
 "The app" = "App";
 "Souce code / report an issue" = "Codice sorgente / segnala un problema";
+"Contact / follow us on Twitter" = "Contattaci / seguici su Twitter";
 "Rate the app on the App Store" = "Valuta l'app sull'App Store";
-"Privacy Policy" = "Norme della Privacy";
+"Privacy Policy" = "Informativa della privacy";
 "Terms of Use" = "Termini d'utilizzo";
 "App version" = "Versione App";
 "Game patch data" = "Dati di gioco";
@@ -782,8 +225,8 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "X-Large" = "Grandissima";
 "XX-Large" = "Enorme";
 "Long" = "Lunga";
-"Large w/Fin" = "Grande senza pinna";
-"Medium w/Fin" = "Media senza pinna";
+"Large w/Fin" = "Grande con pinna";
+"Medium w/Fin" = "Media con pinna";
 "Customizable: %@" = "Personalizzabile: %@";
 "Flick:" = "Ivano:";
 "C.J:" = "Castorino:";
@@ -810,7 +253,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Minmax" = "Min-Max";
 "Profits" = "Profitti";
 "Average daily buy prices" = "Media prezzi giornaliera";
-"Daily min-max prices" = "Prezzi Min-Max giornaliera";
+"Daily min-max prices" = "Prezzi Min-Max giornalieri";
 "Average profits" = "Profitti medi";
 "Chart" = "Grafico";
 "Mon" = "Lun";
@@ -854,6 +297,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Average" = "Media";
 "Minimum" = "Minimo";
 "MinMax" = "MinMax";
+"Services" = "Servizi";
 
 // IslandDetailView
 "Join Island" = "Unisciti all'isola";
@@ -1066,8 +510,8 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Flying near light sources" = "Vola vicino fonti luminose";
 "Flying near trash (boots, tires, cans)" = "Vola vicino rifiuti (Scarponi, copertoni, scatolette)";
 "Flying" = "Vola";
-"Assessing fossils" = "Dissotterrare fossili";
-"Flying near water" = "Vola vicino all'acqua";
+"Assessing fossils" = "Dissotterrare fossili"
+"Flying near water" = "Vola vicino all'acqua"
 "From hitting rocks" = "Colpire le rocce";
 "From Zipper after trading one of every egg (all 6 types) during Bunny Day." = "Da Ovidio scambiando un uovo per tipo (6 tipi) durante la Caccia all'uovo";
 "Glowing dig spot" = "Punto luccicante nel terreno";
@@ -1262,6 +706,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Sea (raining)" = "Mare (Pioggia)";
 "Sea (rainy days)" = "Mare (Quando piove)";
 
+
 // Added 2020-05-13
 "See more" = "Più info";
 "See less" = "Meno info";
@@ -1341,10 +786,10 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Lots of cliffs, waterfalls and river forks. Normal resource spawns." = "Tanti rilievi, cascate e biforcazioni del fiume. Risorse naturali normali";
 "A very rare island with flowers, scorpions and a rectangular pond. If you climb up onto the cliff and climb down from the back, you can vault over to a tiny island in the middle and get 8 gold nuggets from a single rock." = "Un’isola molto rara con fiori, scorpioni e uno stagno rettangolare. Se ti arrampichi sul rilievo e poi scendi dietro dall’altra parte puoi saltare con l’asta su di una piccola isola che sta nel mezzo. Lì puoi prendere 8 minerali d’oro da una roccia.";
 
-// Added 2020-05-20
-"Same color" = "Stesso colore";
-// New settings
-"Using iCloud sync" = "Utilizza sincronizzazione iCloud";
+// Added 2020-05-20		
+"Same color" = "Stesso colore";		
+// New settings		
+"Using iCloud sync" = "Utilizza sincronizzazione iCloud";		
 "Synchronized with iCloud" = "Sincronizzato con iCloud";
 
 "Possible visitors" = "Visitatori possibili";
@@ -1530,7 +975,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Elegant" = "Élegante";
 "Dining" = "Sala da pranzo";
 "Wood Tile Walls" = "Muri Piastrelle di Legno";
-"Tile Floors" = "Pavimenti a Piastrelle";
+"Tile Floors" = Pavimenti a Piastrelle";
 "School" = "Scuola";
 "Cardboard" = "Cartone";
 "Tin Walls" = "Muri di Latta";
@@ -1634,3 +1079,26 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 // Design
 "Creators and Designs" = "Stilisti e Modelli";
 "Add Creator/Design Item" = "Aggiungi uno stilista o un modello";
+
+// Added 2020-06-03
+// Custom Daily Tasks
+"Add a custom task" = "Eigene Aufgabe hinzufügen";
+"Edit task" = "Aufgabe bearbeiten";
+"Task name" = "Aufgabenname";
+"Name of the task" = "Name der Aufgabe";
+"Has progress" = "Hat Fortschritt";
+"Max amount" = "Max. Anzahl";
+// Default Custom Tasks
+"Hit rocks" = "Felsen hauen";
+"Find fossils" = "Fossilien finden";
+"Talk to villager" = "Mit Bewohnern sprechen";
+"Find furniture" = "Möbel in Bäumen finden";
+"Find buried bell" = "Vergrabenen Sterni finden";
+"Use ATM" = "Nook Automat benutzen";
+"Find bottle message" = "Flaschenpost finden";
+"Obtain DIY from villager" = "Bastelanleitung von Bewohner erhalten";
+
+//Villagers filte
+"All" = "Alle";
+"Liked" = "Gefällt mir";
+"Residents" = "Bewohner";

--- a/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
@@ -510,8 +510,8 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Flying near light sources" = "Vola vicino fonti luminose";
 "Flying near trash (boots, tires, cans)" = "Vola vicino rifiuti (Scarponi, copertoni, scatolette)";
 "Flying" = "Vola";
-"Assessing fossils" = "Dissotterrare fossili"
-"Flying near water" = "Vola vicino all'acqua"
+"Assessing fossils" = "Dissotterrare fossili";
+"Flying near water" = "Vola vicino all'acqua";
 "From hitting rocks" = "Colpire le rocce";
 "On rocks/bushes" = "Sulle rocce/cespugli";
 "From Zipper after trading one of every egg (all 6 types) during Bunny Day." = "Da Ovidio scambiando un uovo per tipo (6 tipi) durante la Caccia all'uovo";
@@ -787,7 +787,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Lots of cliffs, waterfalls and river forks. Normal resource spawns." = "Tanti rilievi, cascate e biforcazioni del fiume. Risorse naturali normali";
 "A very rare island with flowers, scorpions and a rectangular pond. If you climb up onto the cliff and climb down from the back, you can vault over to a tiny island in the middle and get 8 gold nuggets from a single rock." = "Un’isola molto rara con fiori, scorpioni e uno stagno rettangolare. Se ti arrampichi sul rilievo e poi scendi dietro dall’altra parte puoi saltare con l’asta su di una piccola isola che sta nel mezzo. Lì puoi prendere 8 minerali d’oro da una roccia.";
 
-// Added 2020-05-20		
+// Added 2020-05-20
 "Same color" = "Stesso colore";
 // New settings
 "Using iCloud sync" = "Utilizza sincronizzazione iCloud";

--- a/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
@@ -513,6 +513,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Assessing fossils" = "Dissotterrare fossili"
 "Flying near water" = "Vola vicino all'acqua"
 "From hitting rocks" = "Colpire le rocce";
+"On rocks/bushes" = "Sulle rocce/cespugli";
 "From Zipper after trading one of every egg (all 6 types) during Bunny Day." = "Da Ovidio scambiando un uovo per tipo (6 tipi) durante la Caccia all'uovo";
 "Glowing dig spot" = "Punto luccicante nel terreno";
 "Gulliver" = "Gulliver";

--- a/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
+++ b/ACHNBrowserUI/ACHNBrowserUI/it.lproj/Localizable.strings
@@ -1071,7 +1071,7 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 "Chore title" = "Nome attività";
 "Description" = "Descrizione";
 "Short description about the chore" = "Una breve descrizione dell'attività";
-"Add Chore" = "Aggiungere una attività";
+"Add Chore" = "Aggiungere un'attività";
 "Chores" = "Attività";
 "Have a friend to visit? A gift to a villager? Track your chores and to-dos here." = "Devi andare a trovare un amico? Dare un regalo ad un abitante? Tieni traccia qui delle tue attività e delle cose da fare.";
 "Reset" = "Reimposta";
@@ -1083,23 +1083,23 @@ Puoi annullare il tuo abbonamento in ogni momento dalle impostazioni del tuo acc
 
 // Added 2020-06-03
 // Custom Daily Tasks
-"Add a custom task" = "Eigene Aufgabe hinzufügen";
-"Edit task" = "Aufgabe bearbeiten";
-"Task name" = "Aufgabenname";
-"Name of the task" = "Name der Aufgabe";
-"Has progress" = "Hat Fortschritt";
-"Max amount" = "Max. Anzahl";
+"Add a custom task" = "Aggiungi obiettivo personalizzato";
+"Edit task" = "Modifica obiettivo";
+"Task name" = "Nome obiettivo";
+"Name of the task" = "Il nome del tuo obiettivo";
+"Has progress" = "Si ripete";
+"Max amount" = "Numero max";
 // Default Custom Tasks
-"Hit rocks" = "Felsen hauen";
-"Find fossils" = "Fossilien finden";
-"Talk to villager" = "Mit Bewohnern sprechen";
-"Find furniture" = "Möbel in Bäumen finden";
-"Find buried bell" = "Vergrabenen Sterni finden";
-"Use ATM" = "Nook Automat benutzen";
-"Find bottle message" = "Flaschenpost finden";
-"Obtain DIY from villager" = "Bastelanleitung von Bewohner erhalten";
+"Hit rocks" = "Colpire rocce";
+"Find fossils" = "Trovare fossili";
+"Talk to villager" = "Parlare con gli abitanti";
+"Find furniture" = "Trovare oggetti";
+"Find buried bell" = "Trovare stelline sottoterra";
+"Use ATM" = "Accedere al Punto Nook";
+"Find bottle message" = "Trovare messaggio in bottiglia";
+"Obtain DIY from villager" = "Ottenere schemi dagli abitanti";
 
 //Villagers filte
-"All" = "Alle";
-"Liked" = "Gefällt mir";
-"Residents" = "Bewohner";
+"All" = "Tutti";
+"Liked" = "Preferiti";
+"Residents" = "Residenti";


### PR DESCRIPTION
I added new translations for custom tasks as seen in the French and German file. 
I noticed that this time the file was partially in Spanish.😖 I don't know why. But I restored the Italian strings and corrected some typos. I added also some missing strings.