### PR TITLE
Remove removed widget from order list

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
@@ -44,8 +44,8 @@ class DashboardViewModel: ObservableObject {
         }
         // If item were removed since the last update, remove from the list
         sectionOrder.forEach { (section) in
-            if !TodaySection.defaultSectionList.contains(section) {
-                sectionOrder.remove(at: sectionOrder.firstIndex(of: section)!)
+            if let obsoletSectionIndex = sectionOrder.firstIndex(of: section) {
+                sectionOrder.remove(at: obsoletSectionIndex)
             }
         }
         selection = Set(sectionOrder.filter(\.enabled).map(\.name))

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/DashboardViewModel.swift
@@ -42,6 +42,12 @@ class DashboardViewModel: ObservableObject {
                 sectionOrder.append(TodaySection(name: section.name, enabled: true))
             }
         }
+        // If item were removed since the last update, remove from the list
+        sectionOrder.forEach { (section) in
+            if !TodaySection.defaultSectionList.contains(section) {
+                sectionOrder.remove(at: sectionOrder.firstIndex(of: section)!)
+            }
+        }
         selection = Set(sectionOrder.filter(\.enabled).map(\.name))
     }
         


### PR DESCRIPTION
Maybe this will never happen, but if we disable / delete a widget from dashboard programmatically it still was in order list. That causes a ui bug.