### PR TITLE
Add notifications section in settings

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/settings/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
                 islandSection
                 appSection
                 dataSection
+                notificationSection
             }
             .listStyle(GroupedListStyle())
             .environment(\.horizontalSizeClass, .regular)
@@ -203,6 +204,16 @@ struct SettingsView: View {
                 Text("Reset my collection").foregroundColor(.red)
             }.alert(isPresented: $showDeleteConfirmationAlert,
                     content: { self.deleteConfirmationAlert })
+        }
+    }
+    
+    private var notificationSection: some View {
+        Section(header: SectionHeaderView(text: "Notifications")) {
+            HStack {
+                Toggle(isOn: $appUserDefaults.shopNotificationsEnabled, label: {
+                    Text("Enable Shop Notifications")
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
Issue: #25 

WIP PR to add push notifications and notifications settings in the app settings menu.

In Progress
- Notifications for when Nook's Cranny and Able Sisters open and close
- Toggle to verify if island time is synced with device time

TODO
- Notifications for special events
- Add toggles for other push notifications

@TheVaan 