### PR TITLE
Improved localization handling of MessageView and SectionHeaderView

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/extensions/Text.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/extensions/Text.swift
@@ -37,7 +37,7 @@ extension Text {
     private func sectionHeader() -> Text {
         self.font(.system(.subheadline, design: .rounded))
             .fontWeight(.bold)
-            .foregroundColor(Color.acSecondaryBackground)
+            .foregroundColor(.acHeaderText)
     }
     
     private func rowTitle() -> Text {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/chores/ChoreListView.swift
@@ -64,7 +64,7 @@ struct ChoreListView: View {
             return EmptyView().eraseToAnyView()
         }
 
-        return MessageView(string: "Have a friend to visit? A gift to a villager? Track your chores and to-dos here.")
+        return MessageView("Have a friend to visit? A gift to a villager? Track your chores and to-dos here.")
             .eraseToAnyView()
     }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/collection/CollectionListView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/collection/CollectionListView.swift
@@ -112,8 +112,7 @@ struct CollectionListView: View {
     }
 
     private var emptyView: some View {
-        let selectedTabName = NSLocalizedString(selectedTab.rawValue, comment: "")
-        return MessageView(collectionName: selectedTabName)
+        MessageView(collectionName: selectedTab.rawValue)
     }
 
     private var picker: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/dodocode/DodoCodeFormView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/dodocode/DodoCodeFormView.swift
@@ -80,7 +80,7 @@ struct DodoCodeFormView: View {
                 }
             }
             .navigationBarItems(leading: dismissButton, trailing: saveButton)
-            .navigationBarTitle(isEditing != nil ? LocalizedStringKey("Edit your Dodo code") : LocalizedStringKey("Add your Dodo code"),
+            .navigationBarTitle(isEditing != nil ? "Edit your Dodo code" : "Add your Dodo code",
                                 displayMode: .inline)
         }
         .navigationViewStyle(StackNavigationViewStyle())

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/MessageView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/MessageView.swift
@@ -16,16 +16,16 @@ struct MessageView: View {
 
     // MARK: - Life cycle
 
-    init(string: LocalizedStringKey) {
+    init(_ string: LocalizedStringKey) {
         self.string = string
     }
 
     init(collectionName: String) {
-        self.string = LocalizedStringKey("When you stars some \(collectionName), they'll be displayed here.")
+        self.string = "When you stars some \(NSLocalizedString(collectionName, comment: "")), they'll be displayed here."
     }
 
     init(noResultsFor string: String) {
-        self.string = LocalizedStringKey("No results for \(string)")
+        self.string = "No results for \(string)"
     }
 
     // MARK: - Public
@@ -41,7 +41,7 @@ struct MessageView: View {
 struct CollectionEmptyView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
-            MessageView(string: "Lorem Ipsum")
+            MessageView("Lorem Ipsum")
                 .previewLayout(.sizeThatFits)
 
             MessageView(collectionName: "Pan-dimensional Mice")

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/SectionHeaderView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/SectionHeaderView.swift
@@ -9,12 +9,16 @@
 import SwiftUI
 
 struct SectionHeaderView: View {
-    let text: String
+    let text: LocalizedStringKey
     var icon: String?
     
-    init(text: String, icon: String? = nil) {
+    init(text: LocalizedStringKey, icon: String? = nil) {
         self.text = text
         self.icon = icon
+    }
+    
+    init(text: String, icon: String? = nil) {
+        self.init(text: LocalizedStringKey(text), icon: icon)
     }
     
     var body: some View {
@@ -27,10 +31,8 @@ struct SectionHeaderView: View {
                     .rotationEffect(.degrees(-3))
             }
             
-            Text(LocalizedStringKey(text))
-                .font(.system(.subheadline, design: .rounded))
-                .fontWeight(.bold)
-                .foregroundColor(.acHeaderText)
+            Text(text)
+                .style(appStyle: .sectionHeader)
                 .lineLimit(1)
         }
         .padding(.vertical, 8)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/userLists/UserListDetailView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/userLists/UserListDetailView.swift
@@ -74,7 +74,7 @@ struct UserListDetailView: View {
                             self.viewModel.deleteItem(at: indexes.first!)
                         }
                     } else {
-                        MessageView(string: "Items added to your list from the search will be displayed there.")
+                        MessageView("Items added to your list from the search will be displayed there.")
                             .listRowBackground(Color.acSecondaryBackground)
                     }
                 } else {


### PR DESCRIPTION
- switched from String to LocalizedStringKey in SectionHeaderView
- overload init from SectionHeaderView to match with init calls where string variables are passed into init
- replaced SectionHeaderView text style modification with style method
- improved MessageView init
- removed unnecessary LocalizedStringKey
- moved collection name translation into init to be more readable