### PR TITLE
Fix retain cycle and VM recreation

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/VillagersViewModel.swift
@@ -57,7 +57,7 @@ class VillagersViewModel: ObservableObject {
             .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .removeDuplicates()
             .filter { !$0.isEmpty }
-            .map(villagers(with:))
+            .map { [weak self] in self?.villagers(with: $0) ?? [] }
             .sink(receiveValue: { [weak self] in self?.searchResults = $0 })
 
         apiPublisher = ACNHApiService.fetch(endpoint: .villagers)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayBirthdaysSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayBirthdaysSection.swift
@@ -11,7 +11,7 @@ import Backend
 import UI
 
 struct TodayBirthdaysSection: View {
-    @ObservedObject private var viewModel = VillagersViewModel()
+    @StateObject private var viewModel = VillagersViewModel()
 
     var headerText: String {
         viewModel.todayBirthdays.count > 1 ? "Today's Birthdays" : "Today's Birthday"


### PR DESCRIPTION
### What

This PR addresses two issues with the `VillagersViewModel`. In particular with its recreation whenever SwiftUI dictates so and the implicit use of `self` as part of its implementation.

### How

1. Make `self` weak and avoid the `map`'s closure capturing `self`.
2. Use `StateObject` instead of `ObservedObject`. Although I am not particular fond of this approach, it fixes the problem where `VillagersViewModel` is being recreated every time the user switches tab on `TodayBirthdaysSection`.

This problem can be seen here:

| Before | After (with this PR) |
|-------|------|
| ![before](https://user-images.githubusercontent.com/949286/85961619-9511c900-b9a3-11ea-9dfe-d381b955ea03.gif) | ![after](https://user-images.githubusercontent.com/949286/85961656-d2765680-b9a3-11ea-8a9e-84ab5ca59f23.gif) |

We can also see the memory growing with the implicit `self` capture:

| Before | After |
|--------|------|
| ![image](https://user-images.githubusercontent.com/949286/85961700-2e40df80-b9a4-11ea-86d1-d869156d73a4.png) | ![image](https://user-images.githubusercontent.com/949286/85961741-6d6f3080-b9a4-11ea-9aca-361154d7a0b0.png) |


