### PR TITLE
Limited the sort method for sea creatures

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/ItemsViewModel.swift
@@ -33,9 +33,9 @@ class ItemsViewModel: ObservableObject {
         private func canSort(_ category: Backend.Category) -> Bool {
             switch self {
             case .buy, .similar, .set:
-                return ![.bugs, .fish, .fossils].contains(category)
+                return ![.bugs, .fish, .seaCreatures, .fossils].contains(category)
             case .critterpedia:
-                return [.bugs, .fish].contains(category)
+                return [.bugs, .fish, .seaCreatures].contains(category)
             default:
                 return true
             }


### PR DESCRIPTION
https://github.com/Dimillian/ACHNBrowserUI/issues/289
The sea creatures should be sorted by critterpedia but not buy, set, or similar.