### PR TITLE
redacted(reason:) syntax tweaks

### DIFF
--- a/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
+++ b/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
@@ -30,7 +30,7 @@ struct VillagerBirthdayWidgetView: View {
             }
             
         }
-        .redacted(reason: model?.villager == nil ? RedactionReasons.placeholder : [])
+        .redacted(reason: model?.villager == nil ? .placeholder : [])
         .widgetURL(URL(string: "achelperapp://villager/\(model?.villager.fileName ?? "null")")!)
     }
     

--- a/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
+++ b/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
@@ -30,7 +30,7 @@ struct VillagerBirthdayWidgetView: View {
             }
             
         }
-        .redacted(reason: model?.villager == nil ? RedactionReasons.placeholder : RedactionReasons()))
+        .redacted(reason: model?.villager == nil ? RedactionReasons.placeholder : [])
         .widgetURL(URL(string: "achelperapp://villager/\(model?.villager.fileName ?? "null")")!)
     }
     

--- a/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
+++ b/ACHNBrowserUI/Widgets/views/VillagerBirthdayWidget.swift
@@ -30,7 +30,7 @@ struct VillagerBirthdayWidgetView: View {
             }
             
         }
-        .redacted(reason: RedactionReasons(rawValue: model?.villager == nil ? RedactionReasons.placeholder.rawValue : 0))
+        .redacted(reason: model?.villager == nil ? RedactionReasons.placeholder : RedactionReasons()))
         .widgetURL(URL(string: "achelperapp://villager/\(model?.villager.fileName ?? "null")")!)
     }
     


### PR DESCRIPTION
Just some minor syntax changes

`[]` can also be used instead of `RedactionReasons()`

Why was `isPlaceholder()` deprecated 😞 