### PR TITLE
fix: update the current date when changing tabs

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
+++ b/ACHNBrowserUI/ACHNBrowserUI.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3DFC04E424D6DAA3002A6CED /* DreamCodeListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFC04E324D6DAA3002A6CED /* DreamCodeListView.swift */; };
 		3DFC04E624D6DAAE002A6CED /* DreamCodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFC04E524D6DAAE002A6CED /* DreamCodeRow.swift */; };
 		3DFC04E824D6DABC002A6CED /* DreamCodeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DFC04E724D6DABC002A6CED /* DreamCodeDetailView.swift */; };
+		4C062B12252BB5BE004DCFA3 /* CurrentDateEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C062B11252BB5BE004DCFA3 /* CurrentDateEnvironment.swift */; };
 		4C30BFC3249627FD003E96A2 /* Sequence+Unique.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C30BFC2249627FC003E96A2 /* Sequence+Unique.swift */; };
 		4C6E95FD24842F690074433B /* Collection+SafeDirectAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C6E95FC24842F690074433B /* Collection+SafeDirectAccess.swift */; };
 		4C7F555D248B91C80089F26C /* TodayVillagerVisitsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7F555C248B91C80089F26C /* TodayVillagerVisitsSection.swift */; };
@@ -237,6 +238,7 @@
 		3DFC04E324D6DAA3002A6CED /* DreamCodeListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCodeListView.swift; sourceTree = "<group>"; };
 		3DFC04E524D6DAAE002A6CED /* DreamCodeRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCodeRow.swift; sourceTree = "<group>"; };
 		3DFC04E724D6DABC002A6CED /* DreamCodeDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DreamCodeDetailView.swift; sourceTree = "<group>"; };
+		4C062B11252BB5BE004DCFA3 /* CurrentDateEnvironment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentDateEnvironment.swift; sourceTree = "<group>"; };
 		4C2D676A245DA41E005831C4 /* TurnipsChartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnipsChartView.swift; sourceTree = "<group>"; };
 		4C2D676D245F0666005831C4 /* TurnipsChartBottomLegendView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnipsChartBottomLegendView.swift; sourceTree = "<group>"; };
 		4C2D676F245F0698005831C4 /* TurnipsChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TurnipsChart.swift; sourceTree = "<group>"; };
@@ -564,6 +566,7 @@
 			children = (
 				696B454B247A948A00E16252 /* MusicPlayerManager.swift */,
 				693E728D245D71DD00CD26F4 /* UIState.swift */,
+				4C062B11252BB5BE004DCFA3 /* CurrentDateEnvironment.swift */,
 			);
 			path = env;
 			sourceTree = "<group>";
@@ -1253,6 +1256,7 @@
 				4C6E95FD24842F690074433B /* Collection+SafeDirectAccess.swift in Sources */,
 				AE2D7EFC247E9726006C1F1A /* DesignListView.swift in Sources */,
 				69157BC12471A5A1005B9002 /* ItemsViewModel.swift in Sources */,
+				4C062B12252BB5BE004DCFA3 /* CurrentDateEnvironment.swift in Sources */,
 				69157BC22471A5A1005B9002 /* TodayEventsSection.swift in Sources */,
 				69157BC32471A5A1005B9002 /* FeedbackGenerator.swift in Sources */,
 				3DFC04E824D6DABC002A6CED /* DreamCodeDetailView.swift in Sources */,

--- a/ACHNBrowserUI/ACHNBrowserUI/env/CurrentDateEnvironment.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/env/CurrentDateEnvironment.swift
@@ -1,0 +1,20 @@
+//
+//  CurrentDateEnvironment.swift
+//  ACHNBrowserUI
+//
+//  Created by Renaud JENNY on 05/10/2020.
+//  Copyright © 2020 Thomas Ricouard. All rights reserved.
+//
+
+import SwiftUI
+
+struct CurrentDateKey: EnvironmentKey {
+    static let defaultValue = Date()
+}
+
+extension EnvironmentValues {
+    var currentDate: Date {
+        get { self[CurrentDateKey.self] }
+        set { self[CurrentDateKey.self] = newValue }
+    }
+}

--- a/ACHNBrowserUI/ACHNBrowserUI/utils/EventsDescription.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/utils/EventsDescription.swift
@@ -38,9 +38,8 @@ extension Event {
         }
     }
     
-    static func nextEvent() -> (Date, Event?) {
+    static func nextEvent(today: Date) -> (Date, Event?) {
         let aDay: TimeInterval = 24*60*60
-        let today = Date()
         let endDate = today.addingTimeInterval(aDay * 365)
         var nextDate = today.addingTimeInterval(aDay)
         var event: Event? = nil

--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/TabbarViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/TabbarViewModel.swift
@@ -16,6 +16,8 @@ class TabbarViewModel: ObservableObject {
     private var musicPlayerPlayingCancellable: AnyCancellable?
     
     @Published var showPlayerView = false
+    @Published private(set) var currentDate = Date()
+    @Published private(set) var cancellables: Set<AnyCancellable> = []
     
     init(musicPlayerManager: MusicPlayerManager) {
         self.musicPlayerManager = musicPlayerManager
@@ -26,5 +28,12 @@ class TabbarViewModel: ObservableObject {
                     self?.showPlayerView = true
                 }
         }
+    }
+
+    func updateCurrentDateOnTabChange(selectedTabPublisher: Published<UIState.Tab>.Publisher) {
+        selectedTabPublisher
+            .removeDuplicates()
+            .sink { [weak self] _ in self?.currentDate = Date() }
+            .store(in: &cancellables)
     }
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/critters/ActiveCrittersView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/critters/ActiveCrittersView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Backend
 
 struct ActiveCritterSections: View {
+    @Environment(\.currentDate) private var currentDate
     @ObservedObject var viewModel: ActiveCrittersViewModel
     @Binding var selectedTab: ActiveCrittersViewModel.CritterType
     
@@ -52,6 +53,9 @@ struct ActiveCritterSections: View {
                 ForEach(viewModel.crittersInfo[selectedTab]?.caught ?? [],
                         content: sectionContent)
             }
+        }
+        .onAppear {
+            viewModel.updateCritters(for: currentDate)
         }
     }
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/home/TabbarView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/home/TabbarView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import Backend
+import Combine
 
 struct TabbarView: View {
     @EnvironmentObject private var uiState: UIState
@@ -51,7 +52,10 @@ struct TabbarView: View {
                         Text("Collection")
                 }
                 .tag(UIState.Tab.collection)
-                
+            }
+            .environment(\.currentDate, viewModel.currentDate)
+            .onAppear {
+                viewModel.updateCurrentDateOnTabChange(selectedTabPublisher: uiState.$selectedTab)
             }
             
             if viewModel.showPlayerView {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/shared/CalendarView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/shared/CalendarView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 import Backend
 
 struct CalendarView: View {
+    @Environment(\.currentDate) private var currentDate
     let activeMonths: [Int]
-    
-    private let currentMonth = Int(Item.monthFormatter.string(from: Date()))!
+
     private let months = [[Calendar.current.shortMonthSymbols[0],
                            Calendar.current.shortMonthSymbols[1],
                            Calendar.current.shortMonthSymbols[2],
@@ -32,6 +32,7 @@ struct CalendarView: View {
 
     private func makeMonthPill(month: String, selected: Bool) -> some View {
         let monthsArray = months.flatMap({ $0 })
+        let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         let isCurrentMonth = monthsArray.firstIndex(of: month) == currentMonth - 1
         let border =  RoundedRectangle(cornerRadius: 10)
             .stroke(lineWidth: isCurrentMonth ? 5 : 0)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayCurrentlyAvailableSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayCurrentlyAvailableSection.swift
@@ -10,6 +10,7 @@ import SwiftUI
 import Backend
 
 struct TodayCurrentlyAvailableSection: View {
+    @Environment(\.currentDate) private var currentDate
     @StateObject private var viewModel = ActiveCrittersViewModel()
     @State private var isNavigationLinkActive = false
     @State private var openingTab: ActiveCrittersViewModel.CritterType = .fish
@@ -102,7 +103,7 @@ struct TodayCurrentlyAvailableSection: View {
     }
     
     private func dayNumber() -> Int {
-        return Calendar.current.dateComponents([.day], from: Date()).day ?? 0
+        return Calendar.current.dateComponents([.day], from: currentDate).day ?? 0
     }
 }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayEventsSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayEventsSection.swift
@@ -11,10 +11,7 @@ import ACNHEvents
 import Backend
 
 struct TodayEventsSection: View {
-
-    let todaysEvents = Date().events(for: AppUserDefaults.shared.hemisphere == .north ? .north : .south)
-    let nextEvent = Event.nextEvent()
-    
+    @Environment(\.currentDate) private var currentDate
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -39,6 +36,12 @@ struct TodayEventsSection: View {
             }
         }
     }
+
+    private var todaysEvents: [Event] {
+        currentDate.events(for: AppUserDefaults.shared.hemisphere == .north ? .north : .south)
+    }
+
+    private var nextEvent: (Date, Event?) { Event.nextEvent(today: currentDate) }
 
     private func subsectionHeader(_ text: String) -> some View {
         Text(LocalizedStringKey(text))

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySpecialCharactersSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodaySpecialCharactersSection.swift
@@ -11,11 +11,12 @@ import SwiftUIKit
 import Backend
 
 struct TodaySpecialCharactersSection: View {
+    @Environment(\.currentDate) private var currentDate
     @State private var selectedCharacter: SpecialCharacters?
     @Namespace private var namespace
     
     private var currentIcon: String {
-        let hour = Calendar.current.component(.hour, from: Date())
+        let hour = Calendar.current.component(.hour, from: currentDate)
         if hour < 9 {
             return "sunrise.fill"
         } else if hour < 17 {
@@ -54,7 +55,7 @@ struct TodaySpecialCharactersSection: View {
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 25)
                     .foregroundColor(.acHeaderBackground)
-                Text(Date(), style: .time)
+                Text(currentDate, style: .time)
                     .style(appStyle: .rowDetail)
             }
             .padding(16)
@@ -96,7 +97,7 @@ struct TodaySpecialCharactersSection: View {
         } else {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 16) {
-                    ForEach(SpecialCharacters.now(), id: \.self) { character in
+                    ForEach(SpecialCharacters.forDate(currentDate), id: \.self) { character in
                         Image(character.rawValue)
                             .resizable()
                             .aspectRatio(contentMode: .fit)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayTurnipSection.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayTurnipSection.swift
@@ -10,10 +10,11 @@ import SwiftUI
 import Backend
 
 struct TodayTurnipSection: View {
+    @Environment(\.currentDate) private var currentDate
     @EnvironmentObject private var turnipService: TurnipPredictionsService
     
     var isSunday: Bool {
-        Calendar.current.component(.weekday, from: Date()) == 1
+        Calendar.current.component(.weekday, from: currentDate) == 1
     }
     
     var body: some View {

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
@@ -88,8 +88,7 @@ struct TodayView: View {
     // MARK: - Others
     private var dateString: String {
         let f = DateFormatter()
-//        f.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
-        f.setLocalizedDateFormatFromTemplate("HH:mm:ssZZZZZ")
+        f.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
         return f.string(from: currentDate)
     }
 }

--- a/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/todayDashboard/TodayView.swift
@@ -15,6 +15,7 @@ import UI
 struct TodayView: View {
     
     // MARK: - Vars
+    @Environment(\.currentDate) private var currentDate
     @StateObject private var viewModel = DashboardViewModel()
     @State private var selectedSheet: Sheet.SheetType?
             
@@ -87,8 +88,9 @@ struct TodayView: View {
     // MARK: - Others
     private var dateString: String {
         let f = DateFormatter()
-        f.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
-        return f.string(from: Date())
+//        f.setLocalizedDateFormatFromTemplate("EEEE, MMM d")
+        f.setLocalizedDateFormatFromTemplate("HH:mm:ssZZZZZ")
+        return f.string(from: currentDate)
     }
 }
 

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/TurnipsFormView.swift
@@ -13,6 +13,7 @@ struct TurnipsFormView: View {
     // MARK: - Properties
     @EnvironmentObject private var subscriptionManager: SubscriptionManager
     @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.currentDate) private var currentDate
     
     @State private var fields = TurnipFields.decode()
     @State private var enableNotifications = SubscriptionManager.shared.subscriptionStatus == .subscribed

--- a/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/turnips/charts/TurnipsChartView.swift
@@ -119,7 +119,8 @@ struct TurnipsChartView_Previews: PreviewProvider {
         minBuyPrice: 83,
         averagePrices: averagePrices,
         minMax: minMax,
-        averageProfits: averageProfits
+        averageProfits: averageProfits,
+        currentDate: Date()
     )
 
     static let averagePrices = [89, 85, 88, 104, 110, 111, 111, 111, 106, 98, 82, 77]

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Extensions/Collection.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Extensions/Collection.swift
@@ -10,8 +10,8 @@ import Foundation
 
 
 public extension BidirectionalCollection where Element == Item {
-    func filterActiveThisMonth() -> [Item] {
-        self.filter({ $0.isActiveThisMonth() })
+    func filterActiveThisMonth(currentDate: Date) -> [Item] {
+        self.filter({ $0.isActiveThisMonth(currentDate: currentDate) })
     }
 }
 

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Item.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Item.swift
@@ -52,7 +52,6 @@ public struct Item: Codable, Equatable, Identifiable, Hashable {
     }
     
     public let name: String
-    public var currentDate: Date
     public let image: String?
     public let filename: String?
     public let house: String?
@@ -164,12 +163,12 @@ public extension Item {
         return nil
     }
     
-    func isActiveThisMonth() -> Bool {
+    func isActiveThisMonth(currentDate: Date) -> Bool {
         let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth - 1) == true
     }
 
-    func isActiveAtThisHour() -> Bool {
+    func isActiveAtThisHour(currentDate: Date) -> Bool {
         guard let hours = activeHours() else { return false }
 
         if hours.start == 0 && hours.end == 0 { return true } // All day
@@ -183,12 +182,12 @@ public extension Item {
         }
     }
     
-    func isNewThisMonth() -> Bool {
+    func isNewThisMonth(currentDate: Date) -> Bool {
         let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth - 2) == false
     }
     
-    func leavingThisMonth() -> Bool {
+    func leavingThisMonth(currentDate: Date) -> Bool {
         let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth) == false
     }
@@ -261,7 +260,6 @@ public extension Sequence {
 }
 
 public let static_item = Item(name: "Acoustic guitar",
-                       currentDate: Date(),
                        image: nil,
                        filename: "https://acnhcdn.com/latest/FtrIcon/FtrAcorsticguitar_Remake_0_0.png",
                        house: nil,

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Item.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Item.swift
@@ -52,6 +52,7 @@ public struct Item: Codable, Equatable, Identifiable, Hashable {
     }
     
     public let name: String
+    public var currentDate: Date
     public let image: String?
     public let filename: String?
     public let house: String?
@@ -164,7 +165,7 @@ public extension Item {
     }
     
     func isActiveThisMonth() -> Bool {
-        let currentMonth = Int(Item.monthFormatter.string(from: Date()))!
+        let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth - 1) == true
     }
 
@@ -173,7 +174,7 @@ public extension Item {
 
         if hours.start == 0 && hours.end == 0 { return true } // All day
 
-        let thisHour = Calendar.current.dateComponents([.hour], from: Date()).hour ?? 0
+        let thisHour = Calendar.current.dateComponents([.hour], from: currentDate).hour ?? 0
 
         if hours.start < hours.end { // Same day
             return thisHour >= hours.start && thisHour < hours.end
@@ -183,12 +184,12 @@ public extension Item {
     }
     
     func isNewThisMonth() -> Bool {
-        let currentMonth = Int(Item.monthFormatter.string(from: Date()))!
+        let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth - 2) == false
     }
     
     func leavingThisMonth() -> Bool {
-        let currentMonth = Int(Item.monthFormatter.string(from: Date()))!
+        let currentMonth = Int(Item.monthFormatter.string(from: currentDate))!
         return activeMonthsCalendar?.contains(currentMonth) == false
     }
     
@@ -260,6 +261,7 @@ public extension Sequence {
 }
 
 public let static_item = Item(name: "Acoustic guitar",
+                       currentDate: Date(),
                        image: nil,
                        filename: "https://acnhcdn.com/latest/FtrIcon/FtrAcorsticguitar_Remake_0_0.png",
                        house: nil,

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/SpecialCharacters.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/SpecialCharacters.swift
@@ -11,9 +11,9 @@ import SwiftUI
 public enum SpecialCharacters: String, CaseIterable {
     case kk, daisy, cj, flick, kicks, saharah, gulliver, label, leif, redd, wisp, celeste
     
-    public static func now() -> [SpecialCharacters] {
-        let day = Calendar.current.component(.weekday, from: Date())
-        let hour = Calendar.current.component(.hour, from: Date())
+    public static func forDate(_ currentDate: Date) -> [SpecialCharacters] {
+        let day = Calendar.current.component(.weekday, from: currentDate)
+        let hour = Calendar.current.component(.hour, from: currentDate)
         if day == 1 {
             return [.daisy]
         } else if day == 7 {

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Turnips.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Models/Turnips.swift
@@ -18,6 +18,7 @@ public struct TurnipPredictions {
     public let averagePrices: [Int]?
     public let minMax: [[Int]]?
     public let averageProfits: [Int]?
+    public var currentDate: Date
     
     public var todayAverages: [Int]? {
         guard let averagePrices = averagePrices else {
@@ -35,12 +36,14 @@ public struct TurnipPredictions {
         minBuyPrice: Int?,
         averagePrices: [Int]?,
         minMax: [[Int]]?,
-        averageProfits: [Int]?
+        averageProfits: [Int]?,
+        currentDate: Date
     ) {
         self.minBuyPrice = minBuyPrice
         self.averagePrices = averagePrices
         self.minMax = minMax
         self.averageProfits = averageProfits
+        self.currentDate = currentDate
     }
 }
 

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Services/TurnipPredictionsService.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Services/TurnipPredictionsService.swift
@@ -30,6 +30,7 @@ public class TurnipPredictionsService: ObservableObject {
         base += "&first=false&pattern=-1&achelper"
         return URL(string: base)
     }
+    public var currentDate = Date()
     
     private var turnipsCancellable: AnyCancellable?
     private lazy var calculatorContext: JSContext? = {
@@ -102,6 +103,7 @@ public class TurnipPredictionsService: ObservableObject {
         return TurnipPredictions(minBuyPrice: results?.toDictionary()["minWeekValue"] as? Int,
                                  averagePrices: averagePrices,
                                  minMax: minMax,
-                                 averageProfits: averageProfits)
+                                 averageProfits: averageProfits,
+                                 currentDate: currentDate)
     }
 }

--- a/ACHNBrowserUI/Packages/Backend/Tests/BackendTests/CrittersTests.swift
+++ b/ACHNBrowserUI/Packages/Backend/Tests/BackendTests/CrittersTests.swift
@@ -127,7 +127,7 @@ final class CrittersTests: XCTestCase {
         let fish = critters.results.first!.content
         
         XCTAssertTrue(fish.isCritter, "This item should be a critter")
-        XCTAssertTrue(fish.isActiveThisMonth(), "This fish should be active all year")
+        XCTAssertTrue(fish.isActiveThisMonth(currentDate: Date()), "This fish should be active all year")
         XCTAssertTrue(fish.activeMonthsCalendar?.count == 12, "This fish should be active all year")
         XCTAssertTrue(fish.appCategory == .fish, "This item should be a fish")
         XCTAssertTrue(fish.formattedTimes() == "4AM - 9PM", "This fish should display all day")


### PR DESCRIPTION
* Fix #325
* Previously the date was only update once the app start. So at some
point if the app survive a night, the date will be wrong. To prevent
that, we update now the date every time the tab is changed