### PR TITLE
fix(Active Critters): load critters when opening Active Critters View

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/views/critters/ActiveCrittersView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/critters/ActiveCrittersView.swift
@@ -61,6 +61,7 @@ struct ActiveCritterSections: View {
 }
 
 struct ActiveCrittersView: View {
+    @Environment(\.currentDate) private var currentDate
     @StateObject private var viewModel = ActiveCrittersViewModel(filterOutInCollection: true)
     @State private var selectedTab: ActiveCrittersViewModel.CritterType
         
@@ -105,6 +106,9 @@ struct ActiveCrittersView: View {
         .tabViewStyle(PageTabViewStyle())
         .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
         .navigationBarTitle("Active Critters", displayMode: .inline)
+        .onAppear {
+            viewModel.updateCritters(for: currentDate)
+        }
     }
 }
 


### PR DESCRIPTION
* Previously, the loading of critters was not triggered, so it displayed
an activity indicators without endlessly
* Fix #330