### PR TITLE
fix(Items Variants Like): tap the like button provide correct feedback

### DIFF
--- a/ACHNBrowserUI/ACHNBrowserUI/viewModels/LikeButtonViewModel.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/viewModels/LikeButtonViewModel.swift
@@ -39,8 +39,7 @@ class LikeButtonViewModel: ObservableObject {
                 guard let self = self else { return }
                 if let item = self.item {
                     if let variant = variant {
-                        self.isInCollection = collection.variantIn(item: item,
-                                                                   variant: variant)
+                        self.isInCollection = variants.contains(for: item, variant: variant)
                         return
                     }
                     self.isInCollection = items.contains(item) || critters.contains(item)

--- a/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
+++ b/ACHNBrowserUI/ACHNBrowserUI/views/items/detail/ItemDetailView.swift
@@ -171,8 +171,7 @@ extension ItemDetailView {
                         FeedbackGenerator.shared.triggerSelection()
                     }
             }
-            LikeButtonView(item: itemViewModel.item,
-                           variant: self.itemViewModel.item.variations?.firstIndex(of: variant) == 0 ? nil : variant)
+            LikeButtonView(item: itemViewModel.item, variant: variant)
         }
     }
     

--- a/ACHNBrowserUI/Packages/Backend/Sources/Backend/Environments/UserCollection.swift
+++ b/ACHNBrowserUI/Packages/Backend/Sources/Backend/Environments/UserCollection.swift
@@ -132,13 +132,6 @@ public class UserCollection: ObservableObject {
         return added
     }
     
-    public func variantIn(item: Item, variant: Variant) -> Bool {
-        guard let filename = item.filename else {
-            return false
-        }
-        return variants[filename]?.contains(variant) == true
-    }
-    
     public func toggleVariant(item: Item, variant: Variant) -> Bool {
         guard let filename = item.filename else {
             return false
@@ -502,5 +495,14 @@ public class UserCollection: ObservableObject {
             save()
         }
         return success
+    }
+}
+
+public extension Dictionary where Key == String, Value == [Variant] {
+    public func contains(for item: Item, variant: Variant) -> Bool {
+        guard let filename = item.filename else {
+            return false
+        }
+        return self[filename]?.contains(variant) == true
     }
 }


### PR DESCRIPTION
* Previously, tapping the Like button did save the current variation but
  the feedback wasn't correct and was only visible after liking another
  variation (or potentially doing another action). It was due to the fact we were
  manipulating directly the collection (ViewModel) inside the `sink`
  callback instead of manipulating the `variations` we received from the
  `sink` callback.
* Partially fix #230. Still need to provide a correct feedback about
  starring "partially" the item if only some of variations have been
  liked. Could be addressed in an another PR.

The bug:

https://user-images.githubusercontent.com/2297556/103180889-2b12a780-4892-11eb-8271-2e3b14727ec5.mov

The fix:

https://user-images.githubusercontent.com/2297556/103180894-36fe6980-4892-11eb-9379-3c84fa560937.mov
